### PR TITLE
Fix for newly-created card not appearing until after you reload

### DIFF
--- a/app/controllers/api/v1/collection_cards_controller.rb
+++ b/app/controllers/api/v1/collection_cards_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
   end
 
   def archive
-    if @collection_card.archive!
+    if @collection_card.archive! && @collection_card.decrement_card_orders!
       @collection_card.reload
       render jsonapi: @collection_card, include: [:parent, record: [:filestack_file]]
     else
@@ -42,8 +42,8 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
   end
 
   def duplicate
-    duplicate = @collection_card.duplicate!
-    if duplicate.persisted? && duplicate.increment_next_card_orders!
+    duplicate = @collection_card.duplicate!(update_order: true)
+    if duplicate.persisted?
       render jsonapi: duplicate, include: [:parent, record: [:filestack_file]]
     else
       render_api_errors duplicate.errors

--- a/app/javascript/stores/jsonApi/CollectionCard.js
+++ b/app/javascript/stores/jsonApi/CollectionCard.js
@@ -4,12 +4,7 @@ class CollectionCard extends BaseRecord {
   API_create() {
     return this.apiStore.request('collection_cards', 'POST', { data: this.toJsonApi() })
       .then((response) => {
-        const newCard = response.data
-        this.parent.collection_cards.push(newCard)
-        // NOTE: reordering happens on the frontend; so we perform this extra save...
-        // could be replaced by reordering on the backend
-        this.parent.API_updateCards()
-        // this.apiStore.sync(response)
+        this.apiStore.fetch('collections', this.parent.id, true)
       })
       .catch((error) => {
         console.warn(error)
@@ -23,6 +18,9 @@ class CollectionCard extends BaseRecord {
       return this.apiStore.request(`collection_cards/${this.id}/archive`, 'PATCH')
         .then((response) => {
           this.apiStore.fetch('collections', this.parent.id, true)
+        })
+        .catch((error) => {
+          console.warn(error)
         })
     }
     return false

--- a/app/javascript/ui/grid/blankContentTool/GridCardBlank.js
+++ b/app/javascript/ui/grid/blankContentTool/GridCardBlank.js
@@ -139,9 +139,7 @@ class GridCardBlank extends React.Component {
 
   createCard = (nested = {}) => {
     const attrs = {
-      // NOTE: technically this uses the same order as the card it is going "next to"
-      // but will be given order + 1 after reorderCards()
-      order: this.props.order,
+      order: this.props.order + 1,
       width: 1,
       height: 1,
       // `parent` is the collection this card belongs to

--- a/app/services/collection_card_builder.rb
+++ b/app/services/collection_card_builder.rb
@@ -19,16 +19,18 @@ class CollectionCardBuilder
       @collection_card.errors.add(:record, "can't be blank")
       return false
     end
-    result = @collection_card.save
-    if result
-      # TODO: rollback transaction if these later actions fail; add errors, return false
-      if @collection_card.collection.present?
-        @user.add_role(Role::EDITOR, @collection_card.collection.becomes(Collection))
-      elsif @collection_card.item.present?
-        @user.add_role(Role::EDITOR, @collection_card.item.becomes(Item))
+
+    @collection_card.save.tap do |result|
+      if result
+        # TODO: rollback transaction if these later actions fail; add errors, return false
+        if @collection_card.collection.present?
+          @user.add_role(Role::EDITOR, @collection_card.collection.becomes(Collection))
+        elsif @collection_card.item.present?
+          @user.add_role(Role::EDITOR, @collection_card.item.becomes(Item))
+        end
+        @collection_card.increment_card_orders!
+        @collection_card.record.reload.recalculate_breadcrumb!
       end
-      @collection_card.record.reload.recalculate_breadcrumb!
     end
-    result
   end
 end

--- a/spec/services/collection_card_builder_spec.rb
+++ b/spec/services/collection_card_builder_spec.rb
@@ -26,15 +26,18 @@ RSpec.describe CollectionCardBuilder, type: :service do
         )
       end
 
-      before do
-        expect(builder.create).to be true
-      end
-
       it 'should add the user as editor to the card\'s child collection' do
+        expect(builder.create).to be true
         expect(user.has_role?(Role::EDITOR, builder.collection_card.collection)).to be true
       end
 
+      it 'should increase order of additional cards' do
+        expect_any_instance_of(CollectionCard).to receive(:increment_card_orders!)
+        expect(builder.create).to be true
+      end
+
       it 'should calculate the breadcrumb for the card\'s child collection' do
+        expect(builder.create).to be true
         created_collection = builder.collection_card.collection
         crumb = ['Collection', parent.id, parent.name]
         expect(created_collection.breadcrumb.first).to eq crumb
@@ -60,17 +63,19 @@ RSpec.describe CollectionCardBuilder, type: :service do
         )
       end
 
-      before do
-        expect(builder.create).to be true
-      end
-
       it 'should calculate the breadcrumb for the card\'s child item' do
+        expect(builder.create).to be true
         created_item = builder.collection_card.item
         crumb = ['Collection', parent.id, parent.name]
         expect(created_item.breadcrumb.first).to eq crumb
 
         crumb = ['Item', created_item.id, 'My item name']
         expect(created_item.breadcrumb.last).to eq crumb
+      end
+
+      it 'should increase order of additional cards' do
+        expect_any_instance_of(CollectionCard).to receive(:increment_card_orders!)
+        expect(builder.create).to be true
       end
     end
 
@@ -89,12 +94,14 @@ RSpec.describe CollectionCardBuilder, type: :service do
         )
       end
 
-      before do
+      it 'should display errors' do
         expect(builder.create).to be false
+        expect(builder.errors.full_messages.first).to eq "Item type can't be blank"
       end
 
-      it 'should display errors' do
-        expect(builder.errors.full_messages.first).to eq "Item type can't be blank"
+      it 'should not increase order of additional cards' do
+        expect_any_instance_of(CollectionCard).not_to receive(:increment_card_orders!)
+        expect(builder.create).to be false
       end
     end
 


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Fix bug where newly-created card doesn't show until reload](https://trello.com/c/gGnNQxpD/138-fix-bug-where-newly-created-card-doesnt-show-until-reload)

- Moves responsibility of re-ordering cards to backend
- Uses same method as other card operations to fetch the collection to get updated data about new card and re-order other cards
- Adds tests for `CollectionCard#duplicate!` that I noticed were never written