### PR TITLE
Fix Text Item Covers

### DIFF
--- a/app/javascript/ui/grid/blankContentTool/TextItemCreator.js
+++ b/app/javascript/ui/grid/blankContentTool/TextItemCreator.js
@@ -3,6 +3,7 @@ import ReactQuill from 'react-quill'
 import _ from 'lodash'
 import styled from 'styled-components'
 
+import { overrideHeadersFromClipboard } from '~/ui/items/TextItem'
 import v, { ITEM_TYPES } from '~/utils/variables'
 
 const StyledTextItemCreator = styled.div`
@@ -25,7 +26,10 @@ class TextItemCreator extends React.Component {
   }
 
   componentDidMount() {
+    if (!this.quillEditor) return
     this.quillEditor.focus()
+    const { editor } = this.quillEditor
+    overrideHeadersFromClipboard(editor)
   }
 
   _onTextChange = (content, delta, source, editor) => {

--- a/app/javascript/ui/items/TextItem.js
+++ b/app/javascript/ui/items/TextItem.js
@@ -15,6 +15,15 @@ const remapHeaderToH3 = (node, delta) => {
   return delta
 }
 
+export const overrideHeadersFromClipboard = (editor) => {
+  // change all non-H3 header attributes to H3, e.g. when copy/pasting
+  editor.clipboard.addMatcher('H1', remapHeaderToH3)
+  editor.clipboard.addMatcher('H2', remapHeaderToH3)
+  editor.clipboard.addMatcher('H4', remapHeaderToH3)
+  editor.clipboard.addMatcher('H5', remapHeaderToH3)
+  editor.clipboard.addMatcher('H6', remapHeaderToH3)
+}
+
 class TextItem extends React.Component {
   constructor(props) {
     super(props)
@@ -25,12 +34,7 @@ class TextItem extends React.Component {
     if (!this.quillEditor) return
     if (this.canEdit) {
       const { editor } = this.quillEditor
-      // change all non-H3 header attributes to H3, e.g. when copy/pasting
-      editor.clipboard.addMatcher('H1', remapHeaderToH3)
-      editor.clipboard.addMatcher('H2', remapHeaderToH3)
-      editor.clipboard.addMatcher('H4', remapHeaderToH3)
-      editor.clipboard.addMatcher('H5', remapHeaderToH3)
-      editor.clipboard.addMatcher('H6', remapHeaderToH3)
+      overrideHeadersFromClipboard(editor)
     }
   }
 


### PR DESCRIPTION
prevent bug where you could add your own H1's by pasting outside text into your TextItemCreator (from BCT)