### PR TITLE
Adds whitelist of attributes for JS to send when doing a save

### DIFF
--- a/app/javascript/stores/jsonApi/CollectionCard.js
+++ b/app/javascript/stores/jsonApi/CollectionCard.js
@@ -4,6 +4,18 @@ import { uiStore } from '~/stores'
 import BaseRecord from './BaseRecord'
 
 class CollectionCard extends BaseRecord {
+  attributesForAPI = [
+    'order',
+    'width',
+    'height',
+    'reference',
+    'parent_id',
+    'collection_id',
+    'item_id',
+    'collection_attributes',
+    'item_attributes',
+  ]
+
   @observable maxWidth = this.width
 
   // this gets set based on number of visible columns, and used by CollectionCover

--- a/app/javascript/stores/jsonApi/Group.js
+++ b/app/javascript/stores/jsonApi/Group.js
@@ -1,6 +1,8 @@
 import BaseRecord from './BaseRecord'
 
-class Group extends BaseRecord {}
+class Group extends BaseRecord {
+  attributesForAPI = ['name', 'handle', 'filestack_file_attributes']
+}
 
 Group.type = 'groups'
 

--- a/app/javascript/stores/jsonApi/Item.js
+++ b/app/javascript/stores/jsonApi/Item.js
@@ -3,6 +3,18 @@ import { archive } from './shared'
 import BaseRecord from './BaseRecord'
 
 class Item extends BaseRecord {
+  attributesForAPI = [
+    'type',
+    'name',
+    'content',
+    'text_data',
+    'url',
+    'image',
+    'archived',
+    'tag_list',
+    'filestack_file_attributes'
+  ]
+
   get parentPath() {
     if (this.breadcrumb && this.breadcrumb.length > 1) {
       const [type, id] = this.breadcrumb[this.breadcrumb.length - 2]


### PR DESCRIPTION
This is a small update -- the `attributesForAPI` on each JS Record tells it which attrs to send through when using the built-in mobx-jsonapi method for `.save()` (i.e. vs. doing an `apiStore.request` where we explicitly pass in the params).

These attrs should basically always match up with our permitted params in the API controllers -- otherwise it'll end up sending _all_ the params through and you'll end up seeing things like `Unpermitted parameters: :id, :is_primary, :filestack_file_url, :rolesMeta` -- no harm in that, but might as well send over a cleaner request. 
