### PR TITLE
Redirects all devise sign_in/sign_up routes to our /login

### DIFF
--- a/app/controllers/users/login_redirect_controller.rb
+++ b/app/controllers/users/login_redirect_controller.rb
@@ -1,0 +1,10 @@
+# Override Devise controller so that /users/[sign_in/new] are not valid routes
+class Users::LoginRedirectController < Devise::SessionsController
+  before_action :redirect_to_profile_login
+
+  private
+
+  def redirect_to_profile_login
+    redirect_to login_url
+  end
+end

--- a/app/devise/devise_login_failure.rb
+++ b/app/devise/devise_login_failure.rb
@@ -1,8 +1,11 @@
 class DeviseLoginFailure < Devise::FailureApp
   # Need to override respond to eliminate Devise `recall` for API auth
   def respond
-    return if request.params[:controller].include? 'api/'
+    return if request.params.present? && request.params[:controller].include?('api/')
+    if request.path == '/sidekiq/unauthenticated'
+      return super
+    end
     store_location!
-    redirect_to login_path
+    redirect_to login_url
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    sessions: 'users/login_redirect',
+    registrations: 'users/login_redirect',
+  }
 
   root to: 'home#index', constraints: ->(req) { req.format == :html || req.format == '*/*' }
 


### PR DESCRIPTION
- Overrides devise routes so that you can't stumble upon `/users/sign_in` or `/users/sign_up` 
- Also fixes unauthenticated `/sidekiq` route (was redirecting to `/sidekiq/login`), because anything sending to `/users/sign_in` will redirect you to our login
