### PR TITLE
Close the search page on no search input

### DIFF
--- a/app/javascript/stores/RoutingStore.js
+++ b/app/javascript/stores/RoutingStore.js
@@ -2,6 +2,12 @@ import { RouterStore } from 'mobx-react-router'
 
 // mobx-react-router with a couple of helper methods
 class RoutingStore extends RouterStore {
+  updatePreviousPageBeforeSearch(page) {
+    if (page.pathname !== '/search') {
+      this.previousPageBeforeSearch = page.pathname
+    }
+  }
+
   pathTo = (type, id) => {
     switch (type) {
     case 'collections':
@@ -12,6 +18,7 @@ class RoutingStore extends RouterStore {
       // `id` means query in this case
       // if no query, then go back to homepage (e.g. clearing out your search)
       if (!id) return '/'
+      this.updatePreviousPageBeforeSearch(this.location)
       return `/search?q=${id.replace(/\s/g, '+')}`
     default:
       return ''

--- a/app/javascript/ui/layout/SearchBar.js
+++ b/app/javascript/ui/layout/SearchBar.js
@@ -89,9 +89,11 @@ class SearchBar extends React.Component {
   }
 
   leaveSearch() {
-    // Find the first route in history that is not search.
-    while (this.props.routingStore.location.pathname === '/search') {
-      this.props.routingStore.history.goBack()
+    const { routingStore } = this.props
+    if (routingStore.previousPageBeforeSearch) {
+      routingStore.routeTo(routingStore.previousPageBeforeSearch)
+    } else {
+      routingStore.routeTo('/')
     }
   }
 


### PR DESCRIPTION
I decided to manipulate the history API to get the user out of search, since it will keep their browser history in a "normal" state.

https://trello.com/c/vNXY76Ho/410-search-can-not-be-closed-when-search-term-is-empty