### PR TITLE
Fix clicking link in text card

### DIFF
--- a/app/javascript/ui/grid/MovableGridCard.js
+++ b/app/javascript/ui/grid/MovableGridCard.js
@@ -143,6 +143,7 @@ class MovableGridCard extends React.PureComponent {
       return
     }
     if (e.target.className.match(/cancelGridClick/)) return
+    if (e.target.tagName === 'A' && e.target.href) return
 
     // timeout is just a stupid thing so that Draggable doesn't complain about unmounting
     setTimeout(() => {


### PR DESCRIPTION
https://trello.com/c/fKZlAUsO/350-clicking-on-a-link-in-a-text-card-should-not-go-into-the-item-view-of-text-item