### PR TITLE
Cancel sync when updating collection card size/order

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -50,6 +50,6 @@ class Api::V1::BaseController < ApplicationController
 
   def check_cancel_sync
     return unless json_api_params && json_api_params[:data]
-    @cancel_sync = json_api_params[:data][:cancel_sync]
+    @cancel_sync = json_api_params[:data].delete :cancel_sync
   end
 end

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -32,6 +32,7 @@ class Api::V1::CollectionsController < Api::V1::BaseController
   def update
     updated = CollectionUpdater.call(@collection, collection_params)
     if updated
+      return if @cancel_sync
       render_collection
     else
       render_api_errors @collection.errors

--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -43,6 +43,8 @@ class Collection extends BaseRecord {
     data.attributes.collection_cards_attributes = _.map(this.collection_cards, card => (
       _.pick(card, ['id', 'order', 'width', 'height'])
     ))
+    // we don't want to receive updates which are just going to try to re-render
+    data.cancel_sync = true
     const apiPath = `collections/${this.id}`
     return this.apiStore.request(apiPath, 'PATCH', { data })
   }

--- a/spec/requests/api/v1/collections_controller_spec.rb
+++ b/spec/requests/api/v1/collections_controller_spec.rb
@@ -220,18 +220,21 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
       create(:collection_card_text, order: 0, width: 1, parent: collection)
     end
     let(:path) { "/api/v1/collections/#{collection.id}" }
+    let(:raw_params) {
+      {
+        id: collection.id,
+        name: 'Who let the dogs out?',
+        collection_cards_attributes: [
+          {
+            id: collection_card.id, order: 1, width: 3
+          }
+        ]
+      }
+    }
     let(:params) {
       json_api_params(
         'collections',
-        {
-          'id': collection.id,
-          'name': 'Who let the dogs out?',
-          'collection_cards_attributes': [
-            {
-              id: collection_card.id, order: 1, width: 3
-            }
-          ]
-        }
+        raw_params
       )
     }
 
@@ -261,6 +264,21 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
       patch(path, params: params)
       expect(collection_card.reload.width).to eq(3)
       expect(collection_card.reload.order).to eq(1)
+    end
+
+    context 'with cancel_sync == true' do
+      let(:params) {
+        json_api_params(
+          'collections',
+          raw_params,
+          { cancel_sync: true }
+        )
+      }
+
+      it 'returns a 204 no content' do
+        patch(path, params: params)
+        expect(response.status).to eq(204)
+      end
     end
   end
 

--- a/spec/requests/api/v1/items_controller_spec.rb
+++ b/spec/requests/api/v1/items_controller_spec.rb
@@ -137,6 +137,21 @@ describe Api::V1::ItemsController, type: :request, json: true, auth: true do
       patch(path, params: params)
       expect(parent.updated_at).to be > parent.created_at
     end
+
+    context 'with cancel_sync == true' do
+      let(:params) {
+        json_api_params(
+          'items',
+          { content: 'The wheels on the bus...' },
+          { cancel_sync: true },
+        )
+      }
+
+      it 'returns a 204 no content' do
+        patch(path, params: params)
+        expect(response.status).to eq(204)
+      end
+    end
   end
 
   describe 'POST #duplicate' do

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -15,12 +15,12 @@ module ApiHelper
     json['data'].map { |obj| obj['attributes']['id'].to_i }
   end
 
-  def json_api_params(resource_name, attrs)
-    {
-      'data' => {
-        'type': resource_name,
-        'attributes': attrs
-      }
+  def json_api_params(resource_name, attrs, merge_data = {})
+    params = {
+      data: {
+        type: resource_name,
+        attributes: attrs
+      }.merge(merge_data)
     }.to_json
   end
 end


### PR DESCRIPTION
Bug: if you made multiple updates to order the cards (particularly on a slow connection) then as the network would return the results of each move (i.e. `PATCH collections#update`) the frontend would try to re-render the results of those previous calls. So you might see the results of your previous moves get re-played out. No need to try to re-render those, since you already have the "correct" size/order of cards being displayed on the frontend, so we use the same `cancel_sync` method that we use for updating text items.
