### PR TITLE
Fix pending user merge

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,13 +8,6 @@ describe User, type: :model do
     it { should validate_presence_of(:provider) }
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:uid).scoped_to(:provider) }
-
-    it 'should not validate uniqueness of email' do
-      email = 'email@me.com'
-      create(:user, email: email, uid: 1)
-      # should allow me to create a second user w/ unique uid, but same email
-      expect(create(:user, email: email, uid: 2)).to be_truthy
-    end
   end
 
   context 'callbacks' do
@@ -113,6 +106,14 @@ describe User, type: :model do
       end
     end
 
+    context 'with pending user found via email' do
+      let!(:email_matching_user) { create(:user, :pending, email: auth.info.email) }
+
+      it 'finds matching user' do
+        expect(from_omniauth.id).to eq email_matching_user.id
+      end
+    end
+
     context 'without existing user' do
       it 'sets up new user record' do
         expect(from_omniauth.new_record?).to be true
@@ -155,11 +156,9 @@ describe User, type: :model do
 
     it 'should include name, email, organization_ids' do
       expect(user.search_data).to eq(
-        {
-          name: user.name,
-          email: user.email,
-          organization_ids: [],
-        }
+        name: user.name,
+        email: user.email,
+        organization_ids: [],
       )
     end
 


### PR DESCRIPTION
script to fix + merge users with dupe emails

```ruby
User.select('count(email) as num, email').group(:email).select{|u| u.num > 1}.each do |ue|
  pending = User.where(email: ue.email).pending.first
  newer = User.where(email: ue.email).where.not(id: pending.id).first

  # move all linked/primary cards into the new user collection
  if pending.current_user_collection
    ccs = pending.current_user_collection.collection_cards.reject{|cc| cc.record.is_a? Collection::SharedWithMeCollection};
    ccs.each {|cc| cc.update(collection_id: newer.current_user_collection_id) };
    pending.collections.select { |c| !c.searchable? }.each(&:destroy);
  end

  new_roles = (
    pending.roles.pluck(:resource_identifier) - newer.roles.pluck(:resource_identifier)
  );
  new_role_ids = pending.roles.where(resource_identifier: new_roles).pluck(:id);
  new_users_roles = pending.users_roles.where(role_id: new_role_ids);
  new_users_roles.update_all(user_id: newer.id);
  pending.destroy  
end
```
