### PR TITLE
Show org name and test name in chart cover

### DIFF
--- a/__js_test_config/mocks/fakeApiStore.js
+++ b/__js_test_config/mocks/fakeApiStore.js
@@ -37,9 +37,9 @@ const fakeApiStore = ({ findResult = '', findAllResult = [], requestResult = '' 
       id: "1",
       current_user_collection_id: 99,
       current_organization: {
-        name: 'test org'
+        name: 'Acme Inc'
       },
-      organizations: [{ name: 'test org 1', filestack_file_url: 'test.jpg' }],
+      organizations: [{ name: 'Acme Inc 1', filestack_file_url: 'test.jpg' }],
       name: 'Johnny Appleseed',
       pic_url_square: 'https://s3.amazonaws.com/pic.png',
       groups: [],
@@ -52,9 +52,9 @@ const fakeApiStore = ({ findResult = '', findAllResult = [], requestResult = '' 
     currentUserOrganization: {
       id: "1",
       slug: 'org-slug',
-      name: 'test org',
+      name: 'Acme Inc',
       primary_group: {
-        name: 'test org',
+        name: 'Acme Inc',
       }
     },
     unreadNotifications: [],

--- a/__tests__/ui/grid/covers/ChartItemCover.unit.test.js
+++ b/__tests__/ui/grid/covers/ChartItemCover.unit.test.js
@@ -1,7 +1,7 @@
 import ChartItemCover from '~/ui/grid/covers/ChartItemCover'
 import { apiStore } from '~/stores'
 
-import { fakeChartItem } from '#/mocks/data'
+import { fakeChartItem, fakeCollection } from '#/mocks/data'
 
 jest.mock('../../../../app/javascript/stores')
 
@@ -11,6 +11,7 @@ describe('ChartItemCover', () => {
   beforeEach(() => {
     props = {
       item: fakeChartItem,
+      testCollection: fakeCollection,
     }
     rerender = () => {
       wrapper = shallow(<ChartItemCover {...props} />)
@@ -51,6 +52,18 @@ describe('ChartItemCover', () => {
           .first()
           .props().data
       ).toEqual(component.formattedData.datasets[0].data)
+    })
+
+    it('renders a legend with org and test collection name', () => {
+      expect(
+        wrapper
+          .find('VictoryLegend')
+          .first()
+          .props().data
+      ).toEqual([
+        { name: fakeCollection.name },
+        { name: 'Acme Inc Organization' },
+      ])
     })
   })
 

--- a/app/javascript/ui/grid/GridCard.js
+++ b/app/javascript/ui/grid/GridCard.js
@@ -104,7 +104,7 @@ class GridCard extends React.Component {
           return <LinkItemCover item={record} dragging={this.props.dragging} />
 
         case ITEM_TYPES.CHART:
-          return <ChartItemCover item={record} />
+          return <ChartItemCover item={record} testCollection={card.parent} />
 
         default:
           return <div>{record.content}</div>

--- a/app/javascript/ui/grid/covers/ChartItemCover.js
+++ b/app/javascript/ui/grid/covers/ChartItemCover.js
@@ -95,6 +95,8 @@ class ChartItemCover extends React.Component {
   }
 
   render() {
+    const currentOrgName = apiStore.currentUserOrganization.name
+    const { testCollection } = this.props
     return (
       <CoverContainer>
         {this.question && (
@@ -174,7 +176,10 @@ class ChartItemCover extends React.Component {
             padding={0}
             rowGutter={0}
             style={{ fill: 'white' }}
-            data={[{ name: 'Age test' }, { name: 'IDEO Organization' }]}
+            data={[
+              { name: testCollection.name },
+              { name: `${currentOrgName} Organization` },
+            ]}
           />
         </VictoryChart>
       </CoverContainer>
@@ -184,6 +189,7 @@ class ChartItemCover extends React.Component {
 
 ChartItemCover.propTypes = {
   item: MobxPropTypes.objectOrObservableObject.isRequired,
+  testCollection: MobxPropTypes.objectOrObservableObject.isRequired,
 }
 
 export default ChartItemCover


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Grouping variable name/legend for a feedback test does not match the test name. It always says “age test” even when the test name is something else.](https://trello.com/c/3ZD3gZ8E/988-grouping-variable-name-legend-for-a-feedback-test-does-not-match-the-test-name-it-always-says-age-test-even-when-the-test-name-i)

![](https://github.trello.services/images/mini-trello-icon.png) [Grouping variable for org comparison for feedback says “IDEO organization” even for non-ideo orgs on the legend. For Kyu organization should say “Kyu organization”](https://trello.com/c/oY27kBIs/987-grouping-variable-for-org-comparison-for-feedback-says-ideo-organization-even-for-non-ideo-orgs-on-the-legend-for-kyu-organizati)
