### PR TITLE
Duplicating objects into template should give them the template 'controls

### DIFF
--- a/app/models/collection_card.rb
+++ b/app/models/collection_card.rb
@@ -64,6 +64,9 @@ class CollectionCard < ApplicationRecord
     if master_template_card? && parent.templated?
       # if we're cloning from template -> templated collection
       cc.templated_from = self
+    elsif parent.master_template?
+      # Make it pinned if you're duplicating it into a master template
+      cc.pinned = true
     elsif !(parent.templated? || parent.master_template?)
       # copying into a normal (non templated) collection, it should never be pinned
       cc.pinned = false

--- a/spec/models/collection_card_spec.rb
+++ b/spec/models/collection_card_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe CollectionCard, type: :model do
         expect(collection_card.pinned?).to be true
         expect(duplicate.pinned?).to be true
       end
+
+      it 'should set pinned even if original was not pinned' do
+        collection_card.update(pinned: false)
+        expect(duplicate.pinned?).to be true
+      end
     end
 
     context 'with linked card and duplicate_linked_records = true' do


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [(0.5) Duplicating objects into template should give them the template 'controls' (e.g. pinned status)](https://trello.com/c/ZuZq4cDG/774-05-duplicating-objects-into-template-should-give-them-the-template-controls-eg-pinned-status)