### PR TITLE
Bug fix: problem with account menu in header

### DIFF
--- a/app/javascript/ui/global/PopoutMenu.js
+++ b/app/javascript/ui/global/PopoutMenu.js
@@ -16,6 +16,11 @@ export const StyledMenuButtonWrapper = styled.div`
     display: block;
     opacity: 1;
     animation: fadeInFromNone 0.25s;
+    ${props =>
+      props.hideDotMenu &&
+      `
+      margin-top: 25px;
+    `};
   }
   @keyframes fadeInFromNone {
     0% {
@@ -174,6 +179,7 @@ class PopoutMenu extends React.Component {
         className={`${wrapperClassName} ${menuOpen && ' open'}`}
         role="presentation"
         onMouseLeave={onMouseLeave}
+        hideDotMenu={hideDotMenu}
       >
         {!hideDotMenu && (
           <MenuToggle

--- a/app/javascript/ui/layout/Header.js
+++ b/app/javascript/ui/layout/Header.js
@@ -134,6 +134,7 @@ class Header extends React.Component {
         width={220}
         menuItems={this.userMenuItems}
         menuOpen={userDropdownOpen}
+        hideDotMenu
       />
     )
   }


### PR DESCRIPTION
The menu was changed at some point and maybe the hideDotMenu prop
was removed from the account header (the dots should only show for the
card menus). Addtionally there was some extra styling to be done.