### PR TITLE
Remove correct remote resource and local copy of payment method

### DIFF
--- a/app/javascript/stores/NetworkStore.js
+++ b/app/javascript/stores/NetworkStore.js
@@ -1,6 +1,7 @@
 import { Collection } from 'datx'
 import { jsonapi, saveModel } from 'datx-jsonapi'
 import { first, find } from 'lodash'
+import { apiUrl as networkApiUrl } from '~shared/api.network.v1/util'
 
 import * as networkModels from '~shared/api.network.v1'
 
@@ -124,6 +125,16 @@ class NetworkStore extends jsonapi(Collection) {
     } catch (e) {
       throw e
     }
+  }
+
+  async removePaymentMethod(paymentMethod) {
+    // we don't use the built in model#destroy or collection#remove
+    // because they have bugs in them.
+    await this.request(
+      `${networkApiUrl('payment_methods')}/${paymentMethod.id}`,
+      'DELETE'
+    )
+    this.remove(paymentMethod, paymentMethod.id)
   }
 }
 

--- a/app/javascript/ui/billing/ManagePaymentMethods.js
+++ b/app/javascript/ui/billing/ManagePaymentMethods.js
@@ -57,8 +57,7 @@ class ManagePaymentMethods extends React.Component {
   }
 
   destroyPaymentMethod = async paymentMethod => {
-    await this.props.networkStore.remove(paymentMethod, paymentMethod.id, true)
-    await this.props.networkStore.remove(paymentMethod, paymentMethod.id)
+    await this.props.networkStore.removePaymentMethod(paymentMethod)
     this.forceUpdate()
   }
 


### PR DESCRIPTION
Every attempt to remove a payment record just removes the first payment method in the store.  Found this while testing something else.

The interface for the `remove` call is very overloaded and confusing: https://github.com/infinum/datx/blob/master/packages/datx-jsonapi/src/decorateCollection.ts#L105

In this case, we were passing `true` as the `id` argument, which is (for some reason) valid, but when you do that you can not specify the `id` that should be removed. It does not infer the `id` from the instance of the model passed, it just passes `undefined` to `removeModel` which causes it to remove the first item in the store.

Attempting to do (what I assumed was) the correct thing based on the code, i tried:

```js
await this.props.networkStore.remove(paymentMethod, paymentMethod.id, true)
```

Which results in the correct record being removed on the remote, but for some reason that leaves the record in place in the local collection.

Making two separate calls, one with remote set to true and one without, removes the correct remote and local records:

```js
await this.props.networkStore.remove(paymentMethod, paymentMethod.id, true)
await this.props.networkStore.remove(paymentMethod, paymentMethod.id)
```

:man_shrugging:

Not sure if there is a better approach.