### PR TITLE
Fix menu positioning on small screens

### DIFF
--- a/app/javascript/ui/grid/GridCard.js
+++ b/app/javascript/ui/grid/GridCard.js
@@ -210,9 +210,9 @@ class GridCard extends React.Component {
   openContextMenu = ev => {
     const { card } = this.props
     const rect = this.gridCardRef.getBoundingClientRect()
-    const x = ev.screenX - rect.left - rect.width
+    const x = ev.clientX - rect.left - rect.width
     const y = ev.screenY - rect.top - 120
-    const direction = ev.screenX < 250 ? 'right' : 'left'
+    const direction = ev.clientX < 250 ? 'right' : 'left'
     if (this.props.menuOpen) {
       uiStore.closeCardMenu()
     } else {

--- a/app/javascript/utils/variables.js
+++ b/app/javascript/utils/variables.js
@@ -86,8 +86,8 @@ export default {
     popoutMenu: 201,
     // NOTE: if globalHeader is > pageHeader
     // then it will also be above the EditableName ClickWrapper
-    globalHeader: 201,
-    pageHeader: 200,
+    globalHeader: 503,
+    pageHeader: 502,
     scrollIndicator: 200,
     gridCard: 150,
     gridCardTop: 151,


### PR DESCRIPTION
Switched the menu positioning to use clientX as opposed to screenX.

ScreenY is still required for the vertical positioning because it takes
scrolling position into account. The clientX provides a consistent
number for the grid cards within different pages sizes, allowing the
horizontal positioning to work.

Additionally, I fixed another bug where right clicking a card would pop
it above the page header. This does mean that you can't click the page
header to get out of the context menu, I'm not sure which part is worse?