### PR TITLE
Add UI for changed template notification in mail

### DIFF
--- a/app/views/notification_mailer/notify.html.erb
+++ b/app/views/notification_mailer/notify.html.erb
@@ -103,7 +103,7 @@
               <% when "mentioned" %>
                 <span class="bold"><%= notification.activity.actor.name %></span> mentioned you in a comment for <span class="bold"><%= notification.activity.target.name %></span>
               <% when "archived_from_template" %>
-                <span class="bold"><%= notification.activity.target.name %> has been changed as a result of <%= notification.activity.source.present? && notification.source.respond_to?(:name) ? notification.activity.source.name : 'something' %> being removed from its template.</span>
+                <span class="bold"><%= notification.activity.target.name %></span> has been changed as a result of <span class="bold"><%= notification.activity.source.present? && notification.activity.source.respond_to?(:name) ? notification.activity.source.name : 'something' %></span> being removed from its template.</span>
               <% end %>
               </p>
             </div>


### PR DESCRIPTION
WHile the frontend had the UI for the changed template notification
updated, the email template did not, so these email notifications
were appearing blank.