### PR TITLE
Clean up automatic org creation

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,13 +53,6 @@ class Organization < ApplicationRecord
     primary_group.can_edit?(user) || admin_group.can_edit?(user) || guest_group.can_edit?(user)
   end
 
-  def self.create_for_user(user)
-    name = [user.first_name, user.last_name, 'Organization'].compact.join(' ')
-    builder = OrganizationBuilder.new({ name: name }, user)
-    builder.save
-    builder.organization
-  end
-
   # NOTE: this method can be called many times for the same org
   def setup_user_membership_and_collections(user)
     # make sure they're on the org
@@ -73,10 +66,6 @@ class Organization < ApplicationRecord
     Roles::RemoveUserRolesFromOrganization.call(self, user)
     profile = Collection::UserProfile.find_by(user: user, organization: self)
     profile.archive! if profile.present?
-
-    if user.organizations.count.zero?
-      Organization.create_for_user(user)
-    end
 
     # Set current org as one they are a member of
     # If nil, that is fine as they shouldn't have a current organization

--- a/app/services/organization_builder.rb
+++ b/app/services/organization_builder.rb
@@ -1,11 +1,13 @@
 class OrganizationBuilder
   attr_reader :organization, :errors
 
-  def initialize(params, user)
+  def initialize(params, user, with_templates: true)
     @organization = Organization.new(name: params[:name])
     @errors = @organization.errors
     @user = user
     @params = params
+    # mainly just in tests that we don't need this overhead
+    @with_templates = with_templates
   end
 
   def save
@@ -14,7 +16,7 @@ class OrganizationBuilder
       update_primary_group!
       add_role
       setup_user_membership_and_collections
-      create_templates
+      create_templates if @with_templates
     end
     true
   rescue ActiveRecord::RecordInvalid

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -125,40 +125,6 @@ describe Organization, type: :model do
     end
   end
 
-  describe '.create_for_user' do
-    let!(:user) { create(:user) }
-    let(:organization) { Organization.create_for_user(user) }
-
-    it 'creates org' do
-      expect { organization }.to change(Organization, :count).by(1)
-    end
-
-    it 'has name: FirstName LastName Organization' do
-      org_name = "#{user.first_name} #{user.last_name} Organization"
-      expect(organization.name).to eq(org_name)
-      expect(organization.slug).to eq(org_name.parameterize)
-    end
-
-    it 'adds user as admin of org\'s primary group' do
-      expect(organization.admins[:users]).to match_array([user])
-    end
-
-    it 'sets user.current_organization' do
-      organization
-      expect(user.reload.current_organization).to eq(organization)
-    end
-
-    context 'with user.last_name blank' do
-      before do
-        user.update_attributes(last_name: nil)
-      end
-
-      it 'has name: FirstName Organization' do
-        expect(organization.name).to eq("#{user.first_name} Organization")
-      end
-    end
-  end
-
   describe '#setup_user_membership' do
     let(:user) { create(:user, email: 'jill@ideo.com') }
     let(:guest) { create(:user, email: 'jack@gmail.com') }
@@ -278,20 +244,6 @@ describe Organization, type: :model do
         organization.remove_user_membership(user)
         organization.setup_user_membership(user)
         expect(profile.reload.archived).to be false
-      end
-    end
-
-    context 'for a user where this was their only organization' do
-      let(:user) { create(:user) }
-
-      before do
-        user.roles.destroy_all
-        user.reload
-      end
-
-      it 'should create a new organization' do
-        expect(Organization).to receive(:create_for_user)
-        organization.remove_user_membership(user)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,10 +76,13 @@ RSpec.configure do |config|
   end
 
   config.before(:each, auth: true) do
-    user = log_in_as_user
-    # Make sure user is part of org - all permissions needs it
-    Organization.create_for_user(user)
-    DatabaseCleaner.strategy = :transaction
+    log_in_as_user
+  end
+
+  # `create_org` only makes sense within specs also tagged `auth`
+  config.before(:each, create_org: true) do
+    # @user from `log_in_as_user` above
+    create_org_for_user(@user)
   end
 
   config.before(:each, truncate: true) do

--- a/spec/requests/api/v1/collection_cards_controller_spec.rb
+++ b/spec/requests/api/v1/collection_cards_controller_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 describe Api::V1::CollectionCardsController, type: :request, json: true, auth: true do
   let(:user) { @user }
+  let(:organization) { create(:organization_without_groups) }
   let(:collection) do
-    create(:collection, add_editors: [user], organization: user.current_organization)
+    create(:collection, add_editors: [user], organization: organization)
   end
   let(:subcollection) do
-    create(:collection, add_editors: [user], organization: user.current_organization)
+    create(:collection, add_editors: [user], organization: organization)
   end
 
   before do
@@ -70,7 +71,7 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
 
     context 'success' do
       let(:collection) do
-        create(:collection, add_content_editors: [user], organization: user.current_organization)
+        create(:collection, add_content_editors: [user], organization: organization)
       end
 
       it 'returns a 200' do
@@ -549,7 +550,7 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
   end
 
   describe 'PATCH #update' do
-    let(:collection) { create(:collection, organization: user.current_organization) }
+    let(:collection) { create(:collection, organization: organization) }
     let(:collection_card) { create(:collection_card_text, parent: collection) }
     let(:path) { "/api/v1/collection_cards/#{collection_card.id}" }
     let(:raw_params) do
@@ -604,7 +605,7 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
   end
 
   describe 'PATCH #replace' do
-    let(:collection) { create(:collection, organization: user.current_organization) }
+    let(:collection) { create(:collection, organization: organization) }
     let(:collection_card) { create(:collection_card_text, parent: collection) }
     let(:path) { "/api/v1/collection_cards/#{collection_card.id}/replace" }
     let(:raw_params) do
@@ -675,7 +676,7 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
       end
 
       context 'with question item params' do
-        let(:collection) { create(:test_collection, organization: user.current_organization) }
+        let(:collection) { create(:test_collection, organization: organization) }
         let(:raw_params) do
           {
             order: 2,

--- a/spec/requests/api/v1/collections_controller_spec.rb
+++ b/spec/requests/api/v1/collections_controller_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 describe Api::V1::CollectionsController, type: :request, json: true, auth: true do
   let(:user) { @user }
 
-  describe 'GET #show' do
+  describe 'GET #show', create_org: true do
     let!(:collection) {
       create(:collection, num_cards: 5, add_viewers: [user])
     }
     let(:path) { "/api/v1/collections/#{collection.id}" }
-    let(:user) { @user }
 
     it 'returns a 200' do
       get(path)

--- a/spec/requests/api/v1/comment_threads_controller_spec.rb
+++ b/spec/requests/api/v1/comment_threads_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::CommentThreadsController, type: :request, json: true, auth: true do
   let(:user) { @user }
 
-  describe 'GET #index' do
+  describe 'GET #index', create_org: true do
     let(:path) { '/api/v1/comment_threads' }
     let!(:comment_threads) do
       create_list(

--- a/spec/requests/api/v1/groups_controller_spec.rb
+++ b/spec/requests/api/v1/groups_controller_spec.rb
@@ -45,7 +45,7 @@ describe Api::V1::GroupsController, type: :request, json: true, auth: true do
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST #create', create_org: true do
     let!(:organization) { create(:organization) }
     let!(:group) { create(:group, add_admins: [user]) }
     let(:current_user) { user }

--- a/spec/requests/api/v1/items_controller_spec.rb
+++ b/spec/requests/api/v1/items_controller_spec.rb
@@ -145,7 +145,7 @@ describe Api::V1::ItemsController, type: :request, json: true, auth: true do
     end
   end
 
-  describe 'POST #duplicate' do
+  describe 'POST #duplicate', create_org: true do
     let!(:item) { create(:text_item, add_editors: [user]) }
     let(:path) { "/api/v1/items/#{item.id}/duplicate" }
 

--- a/spec/requests/api/v1/notifications_controller_spec.rb
+++ b/spec/requests/api/v1/notifications_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Api::V1::NotificationsController, type: :request, json: true, auth: true do
+describe Api::V1::NotificationsController, type: :request, json: true, auth: true, create_org: true do
   let(:user) { @user }
   let(:organization) { user.current_organization }
   let(:collection) { create(:collection) }

--- a/spec/requests/api/v1/roles_controller_spec.rb
+++ b/spec/requests/api/v1/roles_controller_spec.rb
@@ -111,7 +111,7 @@ describe Api::V1::RolesController, type: :request, json: true, auth: true do
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE #destroy', create_org: true do
     # Note: it's important that the group be in the user's current org,
     # or else the API won't give access to it
     let(:organization) { user.current_organization }
@@ -182,7 +182,7 @@ describe Api::V1::RolesController, type: :request, json: true, auth: true do
         end
       end
 
-      context 'as viewer', auth: false do
+      context 'as viewer', auth: false, create_org: false do
         # Needs org and editor created because auth is false
         let!(:organization) { create(:organization) }
         let!(:editor) { create(:user, add_to_org: organization) }

--- a/spec/requests/api/v1/search_controller_spec.rb
+++ b/spec/requests/api/v1/search_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Api::V1::SearchController, type: :request, json: true, auth: true, search: true do
+describe Api::V1::SearchController, type: :request, json: true, auth: true, search: true, create_org: true do
   describe '#GET #search' do
     let!(:current_user) { @user }
     let!(:organization) { current_user.current_organization }

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Api::V1::UsersController, type: :request, json: true, auth: true do
+describe Api::V1::UsersController, type: :request, json: true, auth: true, create_org: true do
   let(:user) { @user }
 
   describe 'GET #index' do

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -4,4 +4,12 @@ module SessionHelper
     login_as(@user, scope: :user)
     @user
   end
+
+  # This used to be a method on Organization -- no longer used outside of tests
+  def create_org_for_user(user)
+    name = [user.first_name, user.last_name, 'Organization'].compact.join(' ')
+    builder = OrganizationBuilder.new({ name: name }, user, with_templates: false)
+    builder.save
+    builder.organization
+  end
 end


### PR DESCRIPTION
Removed Organization.create_for_user method
- This used to happen if you were removed from an org, we'd automatically create one for you -- we no longer want to do that
- Now that org creation is getting heavier (more templates, etc) this also cleans up the specs so that they aren't always building an entire org for every `auth` test