### PR TITLE
Attempt tofix org creation

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -205,10 +205,14 @@ class Organization < ApplicationRecord
   end
 
   def create_groups
-    create_primary_group(name: name, organization: self)
-    create_guest_group(name: guest_group_name, organization: self, handle: guest_group_handle)
-    create_admin_group(name: admin_group_name, organization: self, handle: admin_group_handle)
-    save # Save primary group attr
+    primary_group = create_primary_group(name: name, organization: self)
+    guest_group = create_guest_group(name: guest_group_name, organization: self, handle: guest_group_handle)
+    admin_group = create_admin_group(name: admin_group_name, organization: self, handle: admin_group_handle)
+    update_columns(
+      primary_group_id: primary_group.id,
+      guest_group_id: guest_group.id,
+      admin_group_id: admin_group.id,
+    )
   end
 
   def update_group_names

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -115,6 +115,10 @@ describe Organization, type: :model do
     describe '#friendly_id' do
       let(:organization) { create(:organization) }
 
+      before do
+        organization.save
+      end
+
       it 'generates slug after primary group is saved' do
         expect(
           organization.reload.slug,
@@ -180,7 +184,7 @@ describe Organization, type: :model do
       end
       let(:user_getting_started_collection) do
         user.current_user_collection.collections.where(
-          name: 'Getting Started with Shape'
+          name: 'Getting Started with Shape',
         ).first
       end
 

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -28,6 +28,7 @@ describe Api::V1::OrganizationsController, type: :request, json: true, auth: tru
 
     before do
       user.add_role(Role::MEMBER, organization.primary_group)
+      organization.update(slug: 'some-slug')
     end
 
     it 'returns a 200' do
@@ -44,13 +45,13 @@ describe Api::V1::OrganizationsController, type: :request, json: true, auth: tru
   describe 'POST #create' do
     let(:path) { '/api/v1/organizations/' }
     let!(:current_user) { create(:user) }
-    let(:params) {
+    let(:params) do
       json_api_params(
         'organizations',
         'name': 'IDEO U',
         'handle': 'ideo-u',
       )
-    }
+    end
 
     it 'returns a 200' do
       post(path, params: params)
@@ -63,12 +64,12 @@ describe Api::V1::OrganizationsController, type: :request, json: true, auth: tru
     end
 
     context 'with invalid params' do
-      let(:params) {
+      let(:params) do
         json_api_params(
           'organizations',
           'name': nil,
         )
-      }
+      end
 
       it 'returns a 400 with organization errors' do
         post(path, params: params)
@@ -81,14 +82,12 @@ describe Api::V1::OrganizationsController, type: :request, json: true, auth: tru
   describe 'PATCH #update' do
     let!(:organization) { create(:organization, admin: user) }
     let(:path) { "/api/v1/organizations/#{organization.id}" }
-    let(:params) {
+    let(:params) do
       json_api_params(
         'organizations',
-        {
-          'name': 'Acme Inc 2.0',
-        }
+        'name': 'Acme Inc 2.0',
       )
-    }
+    end
 
     it 'returns a 200' do
       patch(path, params: params)

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -118,8 +118,7 @@ describe Api::V1::UsersController, type: :request, json: true, auth: true, creat
       let!(:org2_user) do
         create(:user,
                first_name: find_user.first_name,
-               last_name: find_user.last_name
-               )
+               last_name: find_user.last_name)
       end
 
       before do
@@ -140,11 +139,11 @@ describe Api::V1::UsersController, type: :request, json: true, auth: true, creat
     let(:emails) { Array.new(3).map { Faker::Internet.email } }
     let(:users_json) { json_included_objects_of_type('users') }
     let(:path) { '/api/v1/users/create_from_emails' }
-    let(:params) {
+    let(:params) do
       {
         'emails': emails,
       }.to_json
-    }
+    end
 
     it 'returns a 200' do
       post(path, params: params)
@@ -211,6 +210,7 @@ describe Api::V1::UsersController, type: :request, json: true, auth: true, creat
 
     before do
       organization.update(slug: 'sluggity-slug')
+      switch_organization.update(slug: 'glug-2')
       user.add_role(Role::MEMBER, switch_organization.primary_group)
     end
 


### PR DESCRIPTION
Josh and I theorized that in certain circumstances on production, the
database commit was happening slower, leading to the `create_groups`
function to be called and saved in a timing where the slug isn't checked
correctly. Changing when the `create_groups` method happens may
fix this issue.

Changing to different way of same previous problem

Fix tests for org slug problem