### PR TITLE
Fix for IE

### DIFF
--- a/app/javascript/ui/test_collections/shared.js
+++ b/app/javascript/ui/test_collections/shared.js
@@ -1,10 +1,10 @@
 import _ from 'lodash'
 import PropTypes from 'prop-types'
-import objectAssignDeep from 'object-assign-deep'
 import styled, { css } from 'styled-components'
 import TextareaAutosize from 'react-autosize-textarea'
 import { VictoryTheme } from 'victory'
 
+import objectAssignDeep from '~/vendor/object-assign-deep'
 import { StyledCommentTextarea } from '~/ui/global/styled/forms'
 import v from '~/utils/variables'
 

--- a/app/javascript/vendor/object-assign-deep.js
+++ b/app/javascript/vendor/object-assign-deep.js
@@ -1,0 +1,145 @@
+/*
+ * OBJECT ASSIGN DEEP
+ * Allows deep cloning of plain objects that contain primitives, nested plain objects, or nested plain arrays.
+ */
+
+/*
+ * A unified way of returning a string that describes the type of the given variable.
+ */
+function getTypeOf(input) {
+  if (input === null) {
+    return 'null'
+  } else if (typeof input === 'undefined') {
+    return 'undefined'
+  } else if (typeof input === 'object') {
+    return Array.isArray(input) ? 'array' : 'object'
+  }
+
+  return typeof input
+}
+
+/*
+ * Branching logic which calls the correct function to clone the given value base on its type.
+ */
+function cloneValue(value) {
+  // The value is an object so lets clone it.
+  if (getTypeOf(value) === 'object') {
+    return quickCloneObject(value)
+  }
+
+  // The value is an array so lets clone it.
+  else if (getTypeOf(value) === 'array') {
+    return quickCloneArray(value)
+  }
+
+  // Any other value can just be copied.
+  return value
+}
+
+/*
+ * Enumerates the given array and returns a new array, with each of its values cloned (i.e. references broken).
+ */
+function quickCloneArray(input) {
+  return input.map(cloneValue)
+}
+
+/*
+ * Enumerates the properties of the given object (ignoring the prototype chain) and returns a new object, with each of
+ * its values cloned (i.e. references broken).
+ */
+function quickCloneObject(input) {
+  const output = {}
+
+  // eslint-disable-next-line
+  for (const key in input) {
+    if (!{}.hasOwnProperty.call(input, key)) {
+      // eslint-disable-next-line
+      continue
+    }
+
+    output[key] = cloneValue(input[key])
+  }
+
+  return output
+}
+
+/*
+ * Does the actual deep merging.
+ */
+function executeDeepMerge(target, _objects = [], _options = {}) {
+  const options = {
+    arrayBehaviour: _options.arrayBehaviour || 'replace', // Can be "merge" or "replace".
+  }
+
+  // Ensure we have actual objects for each.
+  const objects = _objects.map(object => object || {})
+  const output = target || {}
+
+  // Enumerate the objects and their keys.
+  for (let oindex = 0; oindex < objects.length; oindex += 1) {
+    const object = objects[oindex]
+    const keys = Object.keys(object)
+
+    for (let kindex = 0; kindex < keys.length; kindex += 1) {
+      const key = keys[kindex]
+      const value = object[key]
+      const type = getTypeOf(value)
+      const existingValueType = getTypeOf(output[key])
+
+      if (type === 'object') {
+        if (existingValueType !== 'undefined') {
+          const existingValue =
+            existingValueType === 'object' ? output[key] : {}
+          output[key] = executeDeepMerge(
+            {},
+            [existingValue, quickCloneObject(value)],
+            options
+          )
+        } else {
+          output[key] = quickCloneObject(value)
+        }
+      } else if (type === 'array') {
+        if (existingValueType === 'array') {
+          const newValue = quickCloneArray(value)
+          output[key] =
+            options.arrayBehaviour === 'merge'
+              ? output[key].concat(newValue)
+              : newValue
+        } else {
+          output[key] = quickCloneArray(value)
+        }
+      } else {
+        output[key] = value
+      }
+    }
+  }
+
+  return output
+}
+
+/*
+ * Merge all the supplied objects into the target object, breaking all references, including those of nested objects
+ * and arrays, and even objects nested inside arrays. The first parameter is not mutated unlike Object.assign().
+ * Properties in later objects will always overwrite.
+ */
+export default function objectAssignDeep(target, ...objects) {
+  return executeDeepMerge(target, objects)
+}
+
+/*
+ * Same as objectAssignDeep() except it doesn't mutate the target object and returns an entirely new object.
+ */
+export const noMutate = function objectAssignDeepInto(...objects) {
+  return executeDeepMerge({}, objects)
+}
+
+/*
+ * Allows an options object to be passed in to customise the behaviour of the function.
+ */
+export const withOptions = function objectAssignDeepInto(
+  target,
+  objects,
+  options
+) {
+  return executeDeepMerge(target, objects, options)
+}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "mobx-react": "^5.0.0",
     "mobx-react-router": "^4.0.4",
     "moment-mini": "^2.19.4",
-    "object-assign-deep": "^0.4.0",
     "page-metadata-parser": "^1.1.2",
     "papaparse": "^4.6.0",
     "parameterize": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9515,11 +9515,6 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign-deep@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/object-assign-deep/-/object-assign-deep-0.4.0.tgz#43505d3679abb9686ab359b97ac14cc837a9d143"
-  integrity sha512-54Uvn3s+4A/cMWx9tlRez1qtc7pN7pbQ+Yi7mjLjcBpWLlP+XbSHiHbQW6CElDiV4OvuzqnMrBdkgxI1mT8V/Q==
-
 object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"


### PR DESCRIPTION
A vendor library was including code that breaks in IE. It used a
`for in` loop with a `const` definition. While IE can handle `const`
it can't handle it in a `for in` loop.

The fix was to quickly move this library internally to our code so
it gets built.