### PR TITLE
Only send payment_method_id param if it is needed

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -168,11 +168,14 @@ class Organization < ApplicationRecord
       organization_id: network_organization.id,
       default: true,
     ).first
-    NetworkApi::Subscription.create(
+    subscription_params = {
       organization_id: network_organization.id,
       plan_id: plan.id,
-      payment_method_id: payment_method.try(:id),
-    )
+    }
+    if payment_method
+      subscription_params[:payment_method_id] = payment_method.id
+    end
+    NetworkApi::Subscription.create(subscription_params)
   end
 
   def calculate_active_users_count!

--- a/app/services/organization_builder.rb
+++ b/app/services/organization_builder.rb
@@ -11,7 +11,7 @@ class OrganizationBuilder
   end
 
   def save
-    @organization.transaction do
+    result = @organization.transaction do
       @organization.trial_ends_at = Organization::DEFAULT_TRIAL_ENDS_AT.from_now
       @organization.trial_users_count = Organization::DEFAULT_TRIAL_USERS_COUNT
       @organization.save!
@@ -23,8 +23,9 @@ class OrganizationBuilder
         create_network_organization
         create_network_subscription
       end
+      true
     end
-    true
+    !result.nil?
   rescue ActiveRecord::RecordInvalid
     # invalid params, transaction will be rolled back
     false


### PR DESCRIPTION
Sending it with nil causes a parameter error and a 500 from the
profile server.