### PR TITLE
Billing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .byebug_history
 
 /.env
+/.env.test
 /public/packs
 /public/packs-test
 /node_modules

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -179,9 +179,14 @@ class Organization < ApplicationRecord
   end
 
   def calculate_active_users_count!
-    count = users.active
-                 .where('last_active_at > ?', RECENTLY_ACTIVE_RANGE.ago)
-                 .count
+    count = Activity
+            .joins(:actor)
+            .where(User.arel_table[:status].eq(User.statuses[:active]))
+            .where(organization_id: id)
+            .where(Activity.arel_table[:created_at].gt(RECENTLY_ACTIVE_RANGE.ago))
+            .select(:actor_id)
+            .distinct
+            .count
     update_attributes(active_users_count: count)
   end
 

--- a/app/services/organization_builder.rb
+++ b/app/services/organization_builder.rb
@@ -14,6 +14,8 @@ class OrganizationBuilder
     result = @organization.transaction do
       @organization.trial_ends_at = Organization::DEFAULT_TRIAL_ENDS_AT.from_now
       @organization.trial_users_count = Organization::DEFAULT_TRIAL_USERS_COUNT
+      # set it to 1 so that it doesn't start off at 0
+      @organization.active_users_count = 1
       @organization.save!
       update_primary_group!
       add_role

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -48,11 +48,9 @@ FactoryBot.define do
     end
 
     trait :recently_active do
-      last_active_at((Organization::RECENTLY_ACTIVE_RANGE - 1.day).ago)
-    end
-
-    trait :not_recently_active do
-      last_active_at((Organization::RECENTLY_ACTIVE_RANGE + 1.day).ago)
+      after(:create) do |user|
+        create(:activity, organization: user.current_organization, actor: user)
+      end
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -523,13 +523,21 @@ describe Organization, type: :model do
   end
 
   describe '#calculate_active_users_count!' do
-    let(:pending_user) { create(:user, :recently_active, status: User.statuses[:pending], first_name: 'pending_user') }
-    let(:deleted_user) { create(:user, :recently_active, status: User.statuses[:deleted], first_name: 'deleted_user') }
-    let(:recently_active_user) { create(:user, :recently_active, first_name: 'recently_active_user') }
-    let(:recently_active_guest_user) { create(:user, :recently_active, first_name: 'recently_active_guest_user') }
-    let(:not_recently_active_user) { create(:user, :not_recently_active, first_name: 'not_recently_active_user') }
-    let(:not_recently_active_guest_user) { create(:user, :not_recently_active, first_name: 'not_recently_active_guest_user') }
     let(:organization) { create(:organization) }
+    let(:pending_user) do
+      create(:user, :recently_active, current_organization: organization, status: User.statuses[:pending], first_name: 'pending_user')
+    end
+    let(:deleted_user) do
+      create(:user, :recently_active, current_organization: organization, status: User.statuses[:deleted], first_name: 'deleted_user')
+    end
+    let(:recently_active_user) do
+      create(:user, :recently_active, current_organization: organization, first_name: 'recently_active_user')
+    end
+    let(:recently_active_guest_user) do
+      create(:user, :recently_active, current_organization: organization, first_name: 'recently_active_guest_user')
+    end
+    let(:not_recently_active_user) { create(:user, first_name: 'not_recently_active_user') }
+    let(:not_recently_active_guest_user) { create(:user, first_name: 'not_recently_active_guest_user') }
 
     before do
       pending_user.add_role(Role::MEMBER, organization.primary_group)

--- a/spec/services/organization_builder_spec.rb
+++ b/spec/services/organization_builder_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe OrganizationBuilder, type: :service do
       end
 
       it 'should set the default trial user count' do
-        expect(organization.trial_users_count).to eql(Organization::DEFAULT_TRIAL_USERS_COUNT)
+        expect(organization.trial_users_count).to eq Organization::DEFAULT_TRIAL_USERS_COUNT
+      end
+
+      it 'should initialize the active_users_count to 1' do
+        expect(organization.active_users_count).to eq 1
       end
 
       it 'should add the user as an admin role' do


### PR DESCRIPTION
- OrgBuilder automatically starts active_users at 1
- Org's active_users count is tracked based on activity within the org, rather than any activity on the site