### PR TITLE
Updates to BCT handling for collaborative editing

### DIFF
--- a/app/javascript/stores/UiStore.js
+++ b/app/javascript/stores/UiStore.js
@@ -412,9 +412,9 @@ export default class UiStore {
   }
 
   @action
-  closeBlankContentTool() {
+  closeBlankContentTool({ force = false } = {}) {
     const { viewingCollection } = this
-    if (viewingCollection && viewingCollection.isEmpty) {
+    if (!force && viewingCollection && viewingCollection.isEmpty) {
       // shouldn't be allowed to close BCT on empty collection, send back to default
       // -- also helps with the setup of SubmissionBox where you can close the bottom BCT
       this.openBlankContentTool()

--- a/app/javascript/stores/jsonApi/CollectionCard.js
+++ b/app/javascript/stores/jsonApi/CollectionCard.js
@@ -112,8 +112,9 @@ class CollectionCard extends BaseRecord {
       const res = await this.apiStore.request('collection_cards', 'POST', {
         data: this.toJsonApi(),
       })
+      // important to close BCT before adding the new card so that the grid reflows properly
+      uiStore.closeBlankContentTool({ force: true })
       this.parentCollection.addCard(res.data)
-      uiStore.closeBlankContentTool()
       uiStore.trackEvent('create', this.parentCollection)
       return res.data
     } catch (e) {

--- a/app/javascript/ui/grid/CollectionGrid.js
+++ b/app/javascript/ui/grid/CollectionGrid.js
@@ -91,7 +91,6 @@ class CollectionGrid extends React.Component {
     const {
       blankContentToolState,
       collection,
-      cardProperties,
       movingCardIds,
       submissionSettings,
       canEditCollection,
@@ -142,10 +141,7 @@ class CollectionGrid extends React.Component {
         // Increments order from existing BCT order
         blankCard = { ...blankFound, order, width, height }
       }
-      // NOTE: how reliable is this length check for indicating a newly added card?
-      const previousLength = this.props.cardProperties.length
-      const cardJustAdded = cardProperties.length === previousLength + 1
-      if ((canEditCollection && !cardJustAdded) || blankCard.blankType) {
+      if (canEditCollection || blankCard.blankType) {
         // Add the BCT to the array of cards to be positioned, if they can edit
         cards.unshift(blankCard)
       }


### PR DESCRIPTION
- Your current BCT stays open even when new cards are created by other 
editors