### PR TITLE
External Reports: Increase number of records to load

### DIFF
--- a/app/services/data_report/external.rb
+++ b/app/services/data_report/external.rb
@@ -11,6 +11,12 @@ module DataReport
       NetworkApi::AppMetric
         .where(json_api_query_params)
         .order(measured_at: :asc)
+        .per(records_per_page)
+    end
+
+    # Include up to 100 records
+    def records_per_page
+      100
     end
 
     def json_api_query_params


### PR DESCRIPTION
The default was 20, so I increased it to 100.

It would be awesome if we could eventually have a more dynamic way to decide how many records to load, based on desired time frame.