### PR TITLE
New link card text limits

### DIFF
--- a/__tests__/ui/grid/covers/LinkItemCover.unit.test.js
+++ b/__tests__/ui/grid/covers/LinkItemCover.unit.test.js
@@ -10,6 +10,7 @@ describe('LinkItemCover', () => {
   beforeEach(() => {
     props = {
       item: fakeLinkItem,
+      cardHeight: 1,
       dragging: false,
     }
     rerender = () => {
@@ -29,64 +30,68 @@ describe('LinkItemCover', () => {
   })
 
   describe('clamp', () => {
+    const cardHeights = [1, 2]
+    const breakpoints = [
+      {
+        name: 'mobile',
+        width: 480,
+        maxTitle: 53,
+        maxBody: 90,
+      },
+      {
+        name: 'small',
+        width: 768,
+        maxTitle: 46,
+        maxBody: 79,
+      },
+      {
+        name: 'medium',
+        width: 1090,
+        maxTitle: 35,
+        maxBody: 61,
+      },
+      {
+        name: 'large',
+        width: 2000,
+        maxTitle: 40,
+        maxBody: 80,
+      },
+    ]
+
     describe('with a short name', () => {
       beforeEach(() => {
         props.item.name = 'The Verge '
         props.item.content =
-          'E-sports like the Overwatch League, NBA 2K League, and the League of Legends Championship Series are looking to taking on the NBA and NFL with more structure and big-name owners.'
+          'E-sports like the Overwatch League, NBA 2K League, Mega Man II, and the League of Legends Championship Series are looking to taking on the NBA and NFL with more structure and big-name owners.'
         wrapper.setProps(props)
         rerender()
       })
 
-      describe('on the mobile breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 480
-          rerender()
-        })
+      breakpoints.forEach(breakpoint => {
+        describe(`on the ${breakpoint.name} breakpoint`, () => {
+          cardHeights.forEach(height => {
+            const heightLabel = height === 1 ? 'single' : 'double'
+            describe(`at ${heightLabel} square height`, () => {
+              beforeEach(() => {
+                props.cardHeight = height
+                uiStore.windowWidth = breakpoint.width
+                rerender()
+              })
 
-        it('should clamp the content down to 90 characters', () => {
-          expect(wrapper.find('.content').text().length).toEqual(90)
-        })
-      })
-
-      describe('on the small breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 768
-          rerender()
-        })
-
-        it('should clamp the content down to 79 characters', () => {
-          expect(wrapper.find('.content').text().length).toEqual(79)
-        })
-      })
-
-      describe('on the middle breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 1090
-          rerender()
-        })
-
-        it('should clamp the content down to 61 characters', () => {
-          expect(wrapper.find('.content').text().length).toEqual(61)
-        })
-      })
-
-      describe('on the large breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 2000
-          rerender()
-        })
-
-        it('should clamp the content down to 80 characters', () => {
-          expect(wrapper.find('.content').text().length).toEqual(80)
+              const limit = breakpoint.maxBody * height
+              it(`should clamp the content down to ${limit} characters`, () => {
+                expect(wrapper.find('.content').text().length).toEqual(limit)
+              })
+            })
+          })
         })
       })
     })
 
-    describe('with a name longer then 30 characters', () => {
+    describe('with a name longer then 106 characters', () => {
       beforeEach(() => {
         props.item.name =
-          'Soccer News, Live Scores, Results & Transfers | Goal.com US'
+          'Soccer News, Live Scores, Results & Transfers | Goal.com US | The latest soccer news, live scores, results, and rumours from around the world'
         props.item.content =
           'The latest soccer news, live scores, results, rumours, transfers'
         wrapper.setProps(props)
@@ -97,67 +102,28 @@ describe('LinkItemCover', () => {
         expect(wrapper.find('.content').text()).toEqual('')
       })
 
-      describe('on the mobile breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 480
-          rerender()
-        })
+      breakpoints.forEach(breakpoint => {
+        describe(`on the ${breakpoint.name} breakpoint`, () => {
+          cardHeights.forEach(height => {
+            const heightLabel = height === 1 ? 'single' : 'double'
+            describe(`at ${heightLabel} square height`, () => {
+              beforeEach(() => {
+                props.cardHeight = height
+                uiStore.windowWidth = breakpoint.width
+                rerender()
+              })
 
-        it('should clamp the name to 53 characters', () => {
-          expect(
-            wrapper
-              .find('.name')
-              .dive()
-              .text().length
-          ).toEqual(53)
-        })
-      })
-
-      describe('on the small breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 768
-          rerender()
-        })
-
-        it('should clamp the name to 46 characters', () => {
-          expect(
-            wrapper
-              .find('.name')
-              .dive()
-              .text().length
-          ).toEqual(46)
-        })
-      })
-
-      describe('on the middle breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 1090
-          rerender()
-        })
-
-        it('should clamp the name to 35 characters', () => {
-          expect(
-            wrapper
-              .find('.name')
-              .dive()
-              .text().length
-          ).toEqual(35)
-        })
-      })
-
-      describe('on the large breakpoint', () => {
-        beforeEach(() => {
-          uiStore.windowWidth = 2090
-          rerender()
-        })
-
-        it('should clamp the name to 40 characters', () => {
-          expect(
-            wrapper
-              .find('.name')
-              .dive()
-              .text().length
-          ).toEqual(40)
+              const limit = breakpoint.maxTitle * height
+              it(`should clamp the name down to ${limit} characters`, () => {
+                expect(
+                  wrapper
+                    .find('.name')
+                    .dive()
+                    .text().length
+                ).toEqual(limit)
+              })
+            })
+          })
         })
       })
     })

--- a/app/javascript/ui/grid/GridCard.js
+++ b/app/javascript/ui/grid/GridCard.js
@@ -106,7 +106,13 @@ class GridCard extends React.Component {
         case ITEM_TYPES.VIDEO:
           return <VideoItemCover item={record} dragging={this.props.dragging} />
         case ITEM_TYPES.LINK:
-          return <LinkItemCover item={record} dragging={this.props.dragging} />
+          return (
+            <LinkItemCover
+              item={record}
+              cardHeight={card.height}
+              dragging={this.props.dragging}
+            />
+          )
 
         case ITEM_TYPES.CHART:
           return <ChartItemCover item={record} testCollection={card.parent} />

--- a/app/javascript/ui/grid/covers/LinkItemCover.js
+++ b/app/javascript/ui/grid/covers/LinkItemCover.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import styled from 'styled-components'
 import { Flex, Box } from 'reflexbox'
@@ -69,13 +70,16 @@ class LinkItemCover extends React.Component {
         desiredContentLen: 80,
       },
     ]
-
-    const { desiredNameLen, desiredContentLen } = textBreakpoints.reduce(
+    let { desiredNameLen, desiredContentLen } = textBreakpoints.reduce(
       (prev, i) =>
         i.breakpoint && uiStore.windowWidth > i.breakpoint ? i : prev,
       textBreakpoints[0]
     )
-    const { item } = this.props
+    const { item, cardHeight } = this.props
+    if (cardHeight > 1) {
+      desiredNameLen *= 2
+      desiredContentLen *= 2
+    }
     const { name, content } = item
     let truncatedName = name || ''
     let truncatedContent = content || ''
@@ -139,6 +143,11 @@ class LinkItemCover extends React.Component {
 
 LinkItemCover.propTypes = {
   item: MobxPropTypes.objectOrObservableObject.isRequired,
+  cardHeight: PropTypes.number,
+}
+
+LinkItemCover.defaultProps = {
+  cardHeight: 1,
 }
 
 export default LinkItemCover


### PR DESCRIPTION
# Card 

[(0.5) Titles on card covers should wrap to 3 lines on 1 height cards (6 lines on 2 height cards)](https://trello.com/c/PHgyoot4)

# Research

We're limiting these line lengths specifically on the `<LinkItemCover>` the other length limiting of cards appears to be enforced at the model-level (e.g. Collection titles have a max length of 40 chars).

There are two main variables to account for at each breakpoint: grid square size and text size. The combination of these things determines how much text can fit into what size container at any given breakpoint.

We can then use these sizes to compute the appropriate length of content for the placement. Of course, these computations are not perfect because font character widths are variable. So after doing the math I also eyeballed it at each breakpoint to verify that these limits seemed practical.

## Grid square sizes:

**N > largeBreakpoint (1309px+ width)**: \
312px wide cards (272px without the padding)

**N > medBreakpoint && N <= largeBreakpoint (1061-1308 width)**: \
250px wide cards (210px without the padding)

**N <= medBreakpoint (0-1060 width)**: \
312px wide cards (272px without the padding)


## Text sizes:

### Title / Heading1

**N > largeBreakpoint**: \
1.75rem (28px)

**N > smallBreakpoint && N <= largeBreakpoint**: \
1.5rem (24px)

**N <= smallBreakpoint**: \
1.5rem (21px)


### Content

**N > smallBreakpoint**: \
16px

**N <= smallBreakpoint**: \
14px


# Calculating New Limits

Of course, clamping text by # of characters does not get us to a perfect # of lines in a layout. In order to achieve that, we'd need to use a combination of `max-height`, `line-height`, and `text-overflow: hidden`. However, that would lose the ability to truncate text with the ellipsis placed in the middle of the text (or ellipsis placed at all in older browsers).

So in conforming to the format of what we have now, I made two assumptions:

1) Desktop sizes are a close proximity to what we want at the other breakpoints, and

2) Since we're not using a monospace font, we have no way to determine what the width of the text will be. Therefore, take the leap-of-faith that variations in text width will generally average out to some % of the text height, and thus it's safe to make assumptions that are proportionate to `text-size`.


## New Title Limits

**N > largeBreakpoint**: \
WAS: 40 chars @ 28px in a 272px container \
(40 chars * 28px)/272px = *4.11 is our target text/container ratio*

**N > medBreakpoint && N <= largeBreakpoint**: \
WAS: 28 chars @ 24px in a 210px container = 3.2 ratio \
IS: 35 chars @ 24px in a 210px container = 4.0 ratio

**N > smallBreakpoint && N <= medBreakpoint**: \
WAS: 28 chars @ 24px in a 272px container = 2.47 ratio \
IS: 46 chars @ 24px in a 272px container = 4.05 ratio

**N <= smallBreakpoint**: \
WAS: 28 chars @ 21px in a 272px container = 2.16 ratio \
IS: 53 chars @ 21px in a 272px container = 4.09 ratio


## New Content Limits

**N > largeBreakpoint**: \
WAS: 80 chars @ 16px in a 272px container \
(80 chars * 16px)/272px = *4.70 is our target text/container ratio*

**N > medBreakpoint && N <= largeBreakpoint**: \
WAS: 40 chars @ 16px in a 210px container = 3.04 \
IS: 61 chars @ 16px in a 210px container = 4.65

**N > smallBreakpoint && N <= medBreakpoint**: \
WAS: 40 chars @ 16px in a 272px container = 2.35 \
IS: 79 chars @ 16px in a 272px container = 4.65

**N <= smallBreakpoint**: \
WAS: 40 chars @ 14px in a 272px container = 2.06 \
IS: 90 chars @ 14px in a 272px container = 4.63
