### PR TITLE
Font size should not increase when editing

### DIFF
--- a/app/javascript/ui/global/styled/typography.js
+++ b/app/javascript/ui/global/styled/typography.js
@@ -2,22 +2,28 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import v from '~/utils/variables'
 
-const Heading1Css = css`
+export const Heading1TypographyCss = css`
   color: ${v.colors.black};
   font-family: ${v.fonts.sans};
   font-size: 1.75rem;
   font-weight: ${v.weights.book};
   line-height: 2rem;
+  text-transform: none;
+
+  @media only screen and (max-width: ${v.responsive.largeBreakpoint}px) {
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+`
+const Heading1Css = css`
+  ${Heading1TypographyCss};
   margin-bottom: 0.5rem;
   margin-top: 0.5rem;
-  text-transform: none;
   white-space: ${props =>
     props.wrapLine ? 'normal' : 'nowrap'}; /* better this way for responsive? */
 
   @media only screen and (max-width: ${v.responsive.largeBreakpoint}px) {
     padding: 1rem 0;
-    font-size: 1.5rem;
-    line-height: 1.75rem;
   }
 `
 /** @component */

--- a/app/javascript/ui/pages/shared/EditableName.js
+++ b/app/javascript/ui/pages/shared/EditableName.js
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import _ from 'lodash'
 
 import v from '~/utils/variables'
-import { Heading1 } from '~/ui/global/styled/typography'
+import { Heading1, Heading1TypographyCss } from '~/ui/global/styled/typography'
 import ClickWrapper from '~/ui/layout/ClickWrapper'
 
 const StyledName = styled.div`
@@ -24,14 +24,11 @@ StyledName.displayName = 'StyledName'
 const StyledEditableName = styled.div`
   display: block;
   .input__name {
-    margin-bottom: 0.5rem;
-    margin-top: 0.5rem;
+    margin-top: 0.6rem;
     input {
+      ${Heading1TypographyCss};
       z-index: ${v.zIndex.aboveClickWrapper};
       position: relative;
-      font-size: ${props => props.fontSize}rem;
-      font-family: ${v.fonts.sans};
-      font-weight: ${v.weights.medium};
       background-color: transparent;
       border-left: none;
       border-top: none;


### PR DESCRIPTION
# Card

[(0.5) Font size should not increase when entering edit mode of a collection title or other object title in full-screen mode](https://trello.com/c/joR0I9ll)

# Research

The font sizing mismatch at the root of this bug is that `<EditableName/>` is using a `<Heading1/>` to display the text which it switches out for an `<input>` when the user wants to edit it.

# Approach

Since these styles probably matched up at one point in our app's history, I made the typography CSS for the `<Heading1/>` exportable so that we can rely on it to style the input text.

# Improvement Idea

If we had more time to spend, it's worth refactoring this component to always be displaying an input where just the underline is toggled by input focus. This would eliminate any fear of the layout jumping when we go into edit mode. It would also have the added UX benefit of the user's first click setting the cursor's position. We could just use disabled or Heading1 when the user can't edit.
