### PR TITLE
Move Helper Modal UI updates for mobile

### DIFF
--- a/app/javascript/ui/users/MoveHelperModal.js
+++ b/app/javascript/ui/users/MoveHelperModal.js
@@ -109,6 +109,7 @@ class MoveHelperModal extends React.Component {
             <FormControl component="fieldset" required>
               <FormControlLabel
                 classes={{ label: 'form-control' }}
+                style={{ textAlign: 'left' }}
                 control={
                   <Checkbox
                     checked={this.dontShowChecked}


### PR DESCRIPTION
# Card

[(1) Design the move/link/duplicate help modal for mobile. Ensure that user can click the Close Text Button and dismiss the modal.](https://trello.com/c/8bZRrb8l)

# Description

Made some adjustments to the MoveHelperModal in order to better fit mobile devices and ensure close button remains clickable.

# Screenshots

## Mobile 

The work is responsive but iPhone 7 viewport size for demonstration.

<img width="377" alt="screen shot 2019-02-06 at 1 32 22 pm" src="https://user-images.githubusercontent.com/981686/52375377-5d079000-2a14-11e9-8211-35038b77fcb0.png">


## Desktop

<img width="775" alt="screen shot 2019-02-06 at 1 32 41 pm" src="https://user-images.githubusercontent.com/981686/52375399-6b55ac00-2a14-11e9-8325-01f7f96b68c0.png">
