### PR TITLE
Bugfix: Adjust margin for hotspots to better fit gutters

### DIFF
--- a/app/javascript/ui/grid/GridCardHotspot.js
+++ b/app/javascript/ui/grid/GridCardHotspot.js
@@ -28,13 +28,13 @@ const HotspotLine = styled.div`
   height: 100%;
   background: ${v.colors.primaryLight};
   position: relative;
-  left: 7px;
+  left: 4px;
   width: ${props => props.gutter}px;
 `
 
 const StyledPlusIcon = styled.div`
   position: relative;
-  left: -10px;
+  left: -9px;
   width: 12px;
   color: white;
   font-size: 1.5rem;


### PR DESCRIPTION
**What**
Center the hot edge and + in the gutter.

**Why**
Adjusting the gutters caused misalignment of the hot edges.

Tickets/Trello Cards:
https://trello.com/c/tIvmvySk/1436-hot-edges-should-fill-and-be-centered-in-the-new-smaller-gutters