### PR TITLE
Feedback buttons should wrap on mobile

### DIFF
--- a/app/javascript/ui/pages/shared/PageHeader.js
+++ b/app/javascript/ui/pages/shared/PageHeader.js
@@ -53,7 +53,6 @@ const IconHolder = styled.span`
 `
 
 const HeaderFormButton = FormButton.extend`
-  margin-left: 30px;
   margin-top: 10px;
   font-size: 0.825rem;
 `
@@ -359,6 +358,7 @@ class PageHeader extends React.Component {
               justify="space-between"
             >
               <Flex
+                wrap
                 align="center"
                 className="title"
                 onClick={this.handleTitleClick}
@@ -432,7 +432,6 @@ class PageHeader extends React.Component {
                       <HeaderFormButton
                         width="170"
                         color={v.colors.transparent}
-                        style={{ marginLeft: 10 }}
                         onClick={record.closeTest}
                         disabled={uiStore.launchButtonLoading}
                       >

--- a/app/javascript/ui/pages/shared/styled.js
+++ b/app/javascript/ui/pages/shared/styled.js
@@ -24,6 +24,14 @@ export const StyledTitleAndRoles = styled(Flex)`
     @media only screen and (max-width: ${v.responsive.smallBreakpoint}px) {
       padding-top: 10px;
     }
+
+    > * {
+      margin-right: 20px;
+      &:first-child,
+      &:last-child {
+        margin-right: 0px;
+      }
+    }
   }
 `
 


### PR DESCRIPTION
# Card

[(1) Feedback, Templates and Submission Box controls to move outside of the nav](https://trello.com/c/15lqw60y)

# Description

This PR is compatible with the header updates introduced in #453, since that PR takes care of most of the AC on this task, here we're just improving the mobile UX by allowing these elements to wrap.

### Before

Buttons would go off the page
![image](https://user-images.githubusercontent.com/981686/55676200-772ee480-5884-11e9-9108-b0d0fb532d4f.png)


### After

Buttons wrap, with consistent margins

![image](https://user-images.githubusercontent.com/981686/55676194-3cc54780-5884-11e9-98a9-512a7ce02689.png)
