### PR TITLE
Adjust hot edges to fill gutters properly

### DIFF
--- a/app/javascript/ui/grid/GridCardHotspot.js
+++ b/app/javascript/ui/grid/GridCardHotspot.js
@@ -69,7 +69,6 @@ class GridCardHotspot extends React.Component {
   render() {
     const { dragging, uiStore, position } = this.props
     const { icon, line } = this.hotspotMargins
-    console.log(icon, line)
 
     return (
       <StyledHotspot


### PR DESCRIPTION
**What**
Make CSS conditional based on if hotedge is in left or right gutter.

**Why**
Overlooked in previous implementation.
https://github.com/ideo/shape/pull/469

Tickets/Trello Cards:
https://trello.com/c/tIvmvySk/1436-hot-edges-should-fill-and-be-centered-in-the-new-smaller-gutters