### PR TITLE
Shift-click multi-select bug

### DIFF
--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -41,7 +41,8 @@ class Collection extends SharedRecordMixin(BaseRecord) {
 
   @computed
   get cardIds() {
-    return this.collection_cards.map(card => card.id)
+    const sortedCards = _.sortBy(this.collection_cards, card => card.order)
+    return sortedCards.map(card => card.id)
   }
 
   @computed


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Shift-click multi-select bug](https://trello.com/c/8chXpCzu/1411-shift-click-multi-select-bug)

- It was that the card Ids were in the order given by the API, but after a move operation the array order is not changed, so card ids were being iterated over in the original order.