### PR TITLE
Hotfix: Can't delete a test collection item

### DIFF
--- a/app/javascript/ui/test_collections/TestDesigner.js
+++ b/app/javascript/ui/test_collections/TestDesigner.js
@@ -116,7 +116,7 @@ class TestDesigner extends React.Component {
     })
 
   handleTrash = card => {
-    this.confirmEdit(() => card.API_archiveSelf())
+    this.confirmEdit(() => card.API_archiveSelf({}))
   }
 
   handleNew = (card, addBefore) => () => {


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Hotfix: Can't delete a test collection item](https://trello.com/c/b7pETmLE/1505-hotfix-cant-delete-a-test-collection-item)

Need to pass object to card.API_archiveSelf or else `undoable` is attempted to be accessed on nil.