### PR TITLE
Updated logic for truncating/compressing breadcrumbs

### DIFF
--- a/app/javascript/ui/layout/Breadcrumb.js
+++ b/app/javascript/ui/layout/Breadcrumb.js
@@ -1,8 +1,7 @@
-import React from 'react'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import styled from 'styled-components'
-import { floor, round, sumBy, compact } from 'lodash'
 import { Link } from 'react-router-dom'
 
 import { apiStore, routingStore } from '~/stores'
@@ -33,6 +32,7 @@ const BackIconContainer = styled.span`
   color: ${v.colors.black};
   transition: ${v.transition};
   &:hover {
+    cursor: pointer;
     color: ${v.colors.primaryDarkest};
   }
   display: inline-block;
@@ -63,7 +63,7 @@ class Breadcrumb extends React.Component {
       width = this.breadcrumbWrapper.current.offsetWidth
     }
     // roughly .075 characters per pixel
-    return round(width * 0.075)
+    return _.round(width * 0.08)
   }
 
   get previousItem() {
@@ -77,6 +77,7 @@ class Breadcrumb extends React.Component {
   items = (clamp = true) => {
     const { maxDepth, record } = this.props
     const items = []
+    let middleName = ''
     if (record.inMyCollection) {
       items.push({
         type: 'collections',
@@ -89,9 +90,27 @@ class Breadcrumb extends React.Component {
       })
     }
     if (!record.breadcrumb) return items
-    record.breadcrumb.map(item => {
+    const len = record.breadcrumb.length
+    const longBreadcrumb = maxDepth && len >= maxDepth
+
+    _.each(record.breadcrumb, (item, idx) => {
       const { type, id } = item
       const identifier = `${type}_${id}`
+
+      if (longBreadcrumb && idx >= 2 && idx <= len - 3) {
+        // if we have a really long breadcrumb we compress some options in the middle
+        if (middleName) middleName += ' > '
+        middleName += item.name
+        if (idx == len - 3) {
+          return items.push({
+            ...item,
+            name: middleName,
+            ellipses: true,
+            identifier,
+          })
+        }
+        return
+      }
       return items.push({
         ...item,
         truncatedName: null,
@@ -99,22 +118,27 @@ class Breadcrumb extends React.Component {
         identifier,
       })
     })
-    const depth = clamp ? maxDepth * -1 || 0 : 0
-    return compact(items).slice(depth)
+
+    const depth = clamp && maxDepth ? maxDepth * -1 : 0
+    return _.compact(items).slice(depth)
   }
 
+  // totalNameLength keeps getting called, with items potentially truncated
   totalNameLength = items => {
     if (!items) return 0
-    return sumBy(items, item => {
+    return _.sumBy(items, item => {
       let len = 0
+      if (item.ellipses) return
       if (item.truncatedName) len = item.truncatedName.length
       else if (item.name) len = item.name.length
+
       return len
     })
   }
 
-  charsToTruncateForItems = items =>
-    this.totalNameLength(items) - this.calculateMaxChars()
+  charsToTruncateForItems = items => {
+    return this.totalNameLength(items) - this.calculateMaxChars()
+  }
 
   get truncatedItems() {
     return this.truncateItems(this.items())
@@ -126,8 +150,8 @@ class Breadcrumb extends React.Component {
     if (charsLeftToTruncate <= 0) return items
 
     // First try truncating any long items to 25 chars
-    items.forEach(item => {
-      if (item.name && item.name.length > 25) {
+    _.each(items, item => {
+      if (!item.ellipses && item.name && item.name.length > 25) {
         item.truncatedName = item.name.slice(0, 24)
       }
     })
@@ -144,26 +168,44 @@ class Breadcrumb extends React.Component {
 
     // Item names are still too long, show ... in place of their name
     // Start at the midpoint, floor-ing to favor adding ellipses farther up the breadcrumb
-    let index = floor((items.length - 1) / 2)
+    let index = _.floor((items.length - 1) / 2)
 
     // If event number of items, increment index first,
     // otherwise if odd, decrement first
     let increment = items.length % 2 === 0
     let jumpBy = 1
+
     while (charsLeftToTruncate > 0) {
-      if (!items[index]) break
-      if (items[index].name !== 'My Collection') {
+      const item = items[index]
+      if (!item) break
+      if (item.name !== 'My Collection' && !item.ellipses) {
+        // Subtract this item from chars to truncate
+        charsLeftToTruncate -= item.truncatedName
+          ? item.truncatedName.length
+          : item.name.length
         // Continue marking for truncation until we reduce it to be short enough
-        items[index].ellipses = true
-        // Subtract this item from chars to truncate (adding in 2 for ... chars)
-        charsLeftToTruncate -= items[index].name.length + 2
+        item.ellipses = true
+        // clear out truncatedName so that just the ellipses is printed out
+        item.truncatedName = null
       }
       // Traverse on either side of midpoint
       index = increment ? index + jumpBy : index - jumpBy
       jumpBy += 1
       increment = !increment
     }
-    return items
+
+    // last step! combine multiple consecutive ellipses
+    if (items.length > 4) {
+      _.each(items, (item, idx) => {
+        const next = items[idx + 1]
+        if (item.ellipses && next && next.ellipses) {
+          next.name = `${item.name} > ${next.name}`
+          item.remove = true
+        }
+      })
+    }
+
+    return _.reject(items, { remove: true })
   }
 
   renderBackButton() {
@@ -196,7 +238,7 @@ class Breadcrumb extends React.Component {
       inMyCollection !== null &&
       breadcrumb &&
       breadcrumb.length > 0
-    const numItems = this.items().length
+    const items = this.truncatedItems
     // We need a ref to wrapper so we always render that
     // Tried using innerRef on styled component but it isn't available on mount
     return (
@@ -205,13 +247,13 @@ class Breadcrumb extends React.Component {
         {renderItems && (
           <StyledBreadcrumbWrapper>
             {this.renderBackButton()}
-            {this.truncatedItems.map((item, index) => (
+            {items.map((item, index) => (
               <span className="breadcrumb_item" key={item.name}>
                 <BreadcrumbItem
                   identifier={item.identifier}
                   item={item}
                   index={index}
-                  numItems={numItems}
+                  numItems={items.length}
                 />
               </span>
             ))}
@@ -235,7 +277,7 @@ Breadcrumb.propTypes = {
 Breadcrumb.defaultProps = {
   breadcrumbWrapper: React.createRef(),
   containerWidth: null,
-  maxDepth: null,
+  maxDepth: 6,
   backButton: false,
 }
 

--- a/app/javascript/ui/layout/BreadcrumbItem.js
+++ b/app/javascript/ui/layout/BreadcrumbItem.js
@@ -31,6 +31,7 @@ const StyledBreadcrumbItem = styled.div`
     display: inline-block;
     transition: ${v.transition};
     &:hover {
+      cursor: pointer;
       color: ${v.colors.primaryDarkest};
     }
   }

--- a/app/javascript/ui/layout/Header.js
+++ b/app/javascript/ui/layout/Header.js
@@ -280,6 +280,12 @@ class Header extends React.Component {
   }
 
   @computed
+  get maxBreadcrumbContainerWidth() {
+    const outer = this.breadcrumbsWidth - this.actionsWidth
+    return Math.min(outer, 700)
+  }
+
+  @computed
   get isLargeBreakpoint() {
     const { uiStore } = this.props
     return (
@@ -305,7 +311,6 @@ class Header extends React.Component {
     const {
       isMobile,
       isLargeBreakpoint,
-      breadcrumbsWidth,
       record,
       userDropdownOpen,
       orgDropdownOpen,
@@ -341,7 +346,7 @@ class Header extends React.Component {
                     <Flex data-empty-space-click align="center">
                       <div style={{ flex: isMobile ? '1 1 auto' : '0 1 auto' }}>
                         <Breadcrumb
-                          maxDepth={isLargeBreakpoint ? null : 1}
+                          maxDepth={isLargeBreakpoint ? 6 : 1}
                           backButton={!isLargeBreakpoint}
                           record={record}
                           isHomepage={routingStore.isHomepage}
@@ -349,7 +354,7 @@ class Header extends React.Component {
                           key={`${record.identifier}_${record.breadcrumbSize}`}
                           // force props update if windowWidth changes
                           windowWidth={uiStore.windowWidth}
-                          containerWidth={breadcrumbsWidth - this.actionsWidth}
+                          containerWidth={this.maxBreadcrumbContainerWidth}
                         />
                       </div>
                       <Box>


### PR DESCRIPTION
Now multiple items in the middle of the breadcrumb may get compressed into a single ellipses, screenshot attached. Clicking the compressed ellipses will navigate you to the last thing in the list, e.g. clicking "X > Y > Z" will take you to Z.

More conservatively squeezes the breadcrumb into a max width of `700` just to make sure it never runs off the screen (fixing the original bug).

Marked as "feature" and "bug" because the new compression logic is a first pass at an eventual new feature where the compressed breadcrumb would pop open a menu that would allow you to navigate to any of those items, rather than the current "take you to the last one" logic.


![Shape___localhost](https://user-images.githubusercontent.com/318100/56996169-8e49b500-6b58-11e9-98df-594be9c9a7d1.jpg)


