### PR TITLE
retain route after moving cards into a collection

### DIFF
--- a/app/controllers/api/v1/collection_cards_controller.rb
+++ b/app/controllers/api/v1/collection_cards_controller.rb
@@ -117,12 +117,7 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
         create_notification(card,
                             Activity.map_move_action(@card_action))
       end
-      # NOTE: even though this action is in CollectionCardsController, it returns the to_collection
-      # so that it can be easily re-rendered on the page
-      render jsonapi: @to_collection.reload,
-             include: Collection.default_relationships_for_api,
-             meta: { moving_cards: mover.moving_cards.pluck(:id).map(&:to_s) },
-             expose: { current_record: @to_collection }
+      head :no_content
     else
       render json: { errors: mover.errors }, status: :unprocessable_entity
     end

--- a/app/javascript/stores/ApiStore.js
+++ b/app/javascript/stores/ApiStore.js
@@ -456,13 +456,7 @@ class ApiStore extends jsonapi(datxCollection) {
   async moveCards(data) {
     const res = await this.request('collection_cards/move', 'PATCH', data)
     const fromCollection = this.find('collections', data.from_id)
-    if (data.to_id !== data.from_id) {
-      runInAction(() => {
-        fromCollection.removeCardIds(data.collection_card_ids)
-      })
-    } else {
-      await fromCollection.API_fetchCards()
-    }
+    await fromCollection.API_fetchCards()
     return res
   }
 

--- a/app/javascript/stores/RoutingStore.js
+++ b/app/javascript/stores/RoutingStore.js
@@ -41,6 +41,10 @@ class RoutingStore extends RouterStore {
   routeTo = (type, id = null) => {
     this.routingTo = { type, id }
 
+    // prevent accidental route changes while you are dragging/moving into collection
+    if (uiStore.movingIntoCollection) {
+      return
+    }
     // close the org/roles menus if either are open when we route to a new page
     uiStore.update('organizationMenuPage', null)
     uiStore.update('rolesMenuOpen', null)

--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -870,15 +870,9 @@ class Collection extends SharedRecordMixin(BaseRecord) {
       placement: 'beginning',
     }
     await apiStore.moveCards(data)
-    const { movingIntoCollection } = uiStore
     uiStore.setMovingCards([])
     uiStore.update('multiMoveCardIds', [])
-    uiStore.reselectCardIds(cardIds)
     uiStore.update('movingIntoCollection', null)
-    // add a little delay because the board has to load first
-    if (movingIntoCollection.isBoard) {
-      setTimeout(() => uiStore.scrollToBottom(), 500)
-    }
   }
 
   static async createSubmission(parent_id, submissionSettings) {

--- a/spec/requests/api/v1/collection_cards_controller_spec.rb
+++ b/spec/requests/api/v1/collection_cards_controller_spec.rb
@@ -553,9 +553,9 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
         create(:collection, num_cards: 3, add_editors: [user, editor], add_viewers: [viewer])
       end
 
-      it 'returns a 200' do
+      it 'returns a 204' do
         patch(path, params: params)
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(204)
       end
 
       it 'moves cards from one collection to the other' do
@@ -673,9 +673,9 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
         end
       end
 
-      it 'returns a 200' do
+      it 'returns a 204' do
         post(path, params: params)
-        expect(response.status).to eq(200)
+        expect(response.status).to eq(204)
       end
 
       it 'links cards from one collection to the other' do


### PR DESCRIPTION
https://trello.com/c/iDa2vBmd/1520-05-dragging-objects-into-a-collection-should-not-route-the-user-to-the-target-collection