### PR TITLE
Don't allow non-numbers in audience size input

### DIFF
--- a/app/javascript/ui/test_collections/AudienceSettings/TableBody.js
+++ b/app/javascript/ui/test_collections/AudienceSettings/TableBody.js
@@ -35,7 +35,10 @@ EditableInput.displayName = 'EditableInput'
 class TableBody extends React.Component {
   handleInputChange = ev => {
     const { audience, onInputChange } = this.props
-
+    const { value } = ev.target
+    const numberRegex = /^[0-9\b]+$/
+    // Don't allow non-numbers
+    if (value !== '' && !numberRegex.test(value)) return
     onInputChange(audience.id, ev.target.value)
   }
 


### PR DESCRIPTION
I noticed this was an issue when trying out the audience input... so added a regex so non-numeric input isn't allowed.