### PR TITLE
Show turnaround time for feedback to test editor

### DIFF
--- a/app/javascript/ui/test_collections/ConfirmPriceModal.js
+++ b/app/javascript/ui/test_collections/ConfirmPriceModal.js
@@ -41,8 +41,10 @@ class ConfirmPriceModal extends React.Component {
     return (
       <form onSubmit={onSubmit}>
         <SpecialDisplayHeading wrapLine>
-          Your test "{testName}" is about to be launched. Your payment method
-          will be charged <strong>{totalPrice}</strong> for this feedback.
+          "{testName}" is about to be launched. You will receive an email
+          notification when your results are ready in 2-5 business days. Your
+          payment method will be charged <strong>{totalPrice}</strong> for this
+          feedback.
         </SpecialDisplayHeading>
         <StyledDiv
           style={{


### PR DESCRIPTION
**What**
Add messaging about expected turnaround time on sourcing responses when
launching a feedback test.

**Why**
Let feedback editors know when to expect their responses.

Tickets/Trello Cards:
https://trello.com/c/5LRji7O0/1637-0-turnaround-time-to-completion-of-feedback-is-communicated-to-the-feedback-editor