### PR TITLE
The "you're done" 'question' should appear before the 'opt-in to recontact' module

### DIFF
--- a/app/javascript/ui/test_collections/TestSurveyResponder.js
+++ b/app/javascript/ui/test_collections/TestSurveyResponder.js
@@ -50,11 +50,19 @@ class TestSurveyResponder extends React.Component {
 
     const questionCards = [...collection.question_cards]
 
+    const questionFinishIndex = _.findIndex(
+      questionCards,
+      card => card.card_question_type === 'question_finish'
+    )
+
     if (includeRecontactQuestion) {
-      questionCards.splice(questionCards.length - 1, 0, {
+      // Put recontact question after the finish question
+      const recontactOrder = questionCards[questionFinishIndex].order + 1
+      questionCards.splice(questionFinishIndex + 1, 0, {
         id: 'recontact',
         card_question_type: 'question_recontact',
-        record: { id: 'facsda', content: '' },
+        order: recontactOrder,
+        record: { id: 'recontact_item', content: '' },
       })
     }
     if (includeTerms) {


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [(0.5) The "you're done" 'question' (along with incentive interaction if applicable) should appear before the 'opt-in to recontact' module (if applicable)](https://trello.com/c/TgilOrCK/1622-05-the-youre-done-question-along-with-incentive-interaction-if-applicable-should-appear-before-the-opt-in-to-recontact-module-if)