### PR TITLE
Fix confirm payment modal rendering logic

### DIFF
--- a/app/javascript/ui/test_collections/ConfirmPriceModal.js
+++ b/app/javascript/ui/test_collections/ConfirmPriceModal.js
@@ -72,13 +72,16 @@ class ConfirmPriceModal extends React.Component {
       : `${organization.name}'s default payment method will be charged.`
     const paymentBrand = paymentMethod ? paymentMethod.brand : null
 
-    // Is this logic working right?
-    return this.isOrgAdmin ? (
-      <React.Fragment>
-        <CardBrandIcon brand={paymentBrand} width={32} height={30} />{' '}
-        <DisplayText>{message}</DisplayText>
-      </React.Fragment>
-    ) : (
+    if (this.hasPaymentMethod) {
+      return (
+        <React.Fragment>
+          <CardBrandIcon brand={paymentBrand} width={32} height={30} />{' '}
+          <DisplayText>{message}</DisplayText>
+        </React.Fragment>
+      )
+    }
+
+    return (
       <React.Fragment>
         <CardBrandIcon brand={null} width={32} height={30} />
         <DisplayText>
@@ -116,7 +119,7 @@ class ConfirmPriceModal extends React.Component {
         </StyledModalCloseButton>
         <StyledDialogContent classes={{ root: 'root__dialog-content' }}>
           <PaperAirplane />
-          {this.hasPaymentMethod
+          {this.hasPaymentMethod || this.isOrgAdmin
             ? this.renderPaymentMethodContent()
             : this.renderMissingPaymentContent()}
         </StyledDialogContent>


### PR DESCRIPTION
**What**
Revise logic to show correct text based on having payment method and/or
being an admin.

**Why**
Feedback editors were getting wrong messages when attempting to launch
their tests.

**Note:**
Bug introduced in this [ticket](https://trello.com/c/Umqk2s5w/1271-1-the-feedback-editor-must-agree-to-the-price-when-launching-a-test) as part of this [PR](https://github.com/ideo/shape/pull/551).