### PR TITLE
fix collection cover onClick handler bug for search results

### DIFF
--- a/app/javascript/ui/grid/CoverRenderer.js
+++ b/app/javascript/ui/grid/CoverRenderer.js
@@ -104,6 +104,7 @@ class CoverRenderer extends React.Component {
           height={card.maxHeight}
           collection={record}
           dragging={dragging}
+          searchResult={searchResult}
           inSubmissionsCollection={
             card.parentCollection &&
             card.parentCollection.isSubmissionsCollection

--- a/app/javascript/ui/grid/covers/CollectionCover.js
+++ b/app/javascript/ui/grid/covers/CollectionCover.js
@@ -246,7 +246,7 @@ class CollectionCover extends React.Component {
   }
 
   handleClick = e => {
-    const { dragging, uiStore, collection } = this.props
+    const { searchResult, dragging, uiStore, collection } = this.props
     const makingSelection =
       (e.metaKey || e.ctrlKey || e.shiftKey) && uiStore.selectedCardIds.length
     if (dragging || makingSelection) {
@@ -254,7 +254,7 @@ class CollectionCover extends React.Component {
       return false
     }
 
-    if (collection.can_view) return true
+    if (collection.can_view || searchResult) return true
 
     // User does not have permission to see collection
     e.preventDefault()
@@ -264,7 +264,7 @@ class CollectionCover extends React.Component {
   }
 
   render() {
-    const { height, width, collection, uiStore, onClick } = this.props
+    const { height, width, collection, uiStore } = this.props
     const { cover } = collection
     const { gridW, gutter } = uiStore.gridSettings
 
@@ -273,8 +273,6 @@ class CollectionCover extends React.Component {
         data-cy="CollectionCover"
         url={this.coverImageUrl}
         isSpecialCollection={collection.isSpecialCollection}
-        // onClick can be null, is used by SearchResultsInfinite
-        onClick={onClick}
       >
         <StyledCardContent
           height={height}
@@ -318,7 +316,7 @@ CollectionCover.propTypes = {
   collection: MobxPropTypes.objectOrObservableObject.isRequired,
   inSubmissionsCollection: PropTypes.bool,
   dragging: PropTypes.bool,
-  onClick: PropTypes.func,
+  searchResult: PropTypes.bool,
 }
 CollectionCover.wrappedComponent.propTypes = {
   uiStore: MobxPropTypes.objectOrObservableObject.isRequired,
@@ -326,7 +324,7 @@ CollectionCover.wrappedComponent.propTypes = {
 CollectionCover.defaultProps = {
   inSubmissionsCollection: false,
   dragging: false,
-  onClick: null,
+  searchResult: false,
 }
 
 CollectionCover.displayName = 'CollectionCover'


### PR DESCRIPTION
**What**
Each search result item had conflicting onClick behavior:
1. clicking on the link on the collection cover won't redirect the user to the collection
2. clicking on the card around the link will redirect the user to the collection

This PR redirects the user to the collection for each search result item's link is clicked

**Other Notes**
Looks like `CollectionCover`'s `onClick` prop is never passed from its [parent component](https://github.com/ideo/shape/blob/development/app/javascript/ui/grid/CoverRenderer.js#L102-L110) or elsewhere in the codebase, hence the removal.