### PR TITLE
Confirm survey completion after payment earned

### DIFF
--- a/app/javascript/ui/test_collections/RecontactQuestion.js
+++ b/app/javascript/ui/test_collections/RecontactQuestion.js
@@ -252,7 +252,9 @@ class RecontactQuestion extends React.Component {
       <div style={{ width: '100%', backgroundColor: this.backgroundColor }}>
         {showFeedbackRecontact === 'noIncentiveForGuest' &&
           this.showFeedbackRecontactForm}
-        {answer === 'feedback_contact_no' && this.showPostOptInConfirmation}
+        {answer === 'feedback_contact_no' &&
+          !submittedContactInfo &&
+          this.showPostOptInConfirmation}
 
         {showContactInfo && this.showContactInfoForm}
 


### PR DESCRIPTION
### What
Add additional messaging and logic around survey completion.

### Why
Survey respondents were feeling stuck/confused after answering the
recontact question since there was no interaction/follow up to tell them
that they were done.

**Trello card**:
https://trello.com/c/suAX7h6Q/1769-increased-confirmation-when-of-payment-earned-and-completion-when-a-user-finishes-a-survey