### PR TITLE
Allow external id + collection params when creating template instance

### DIFF
--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::CollectionsController < Api::V1::BaseController
       placement: json_api_params[:placement],
       created_by: current_user,
       external_id: json_api_params[:external_id],
+      collection_params: json_api_params[:collection].present? ? json_api_collection_params : {},
     )
 
     if builder.call
@@ -190,7 +191,15 @@ class Api::V1::CollectionsController < Api::V1::BaseController
   end
 
   def collection_params
-    params.require(:collection).permit(
+    params.require(:collection).permit(permitted_collection_params)
+  end
+
+  def json_api_collection_params
+    json_api_params.require(:collection).permit(permitted_collection_params)
+  end
+
+  def permitted_collection_params
+    [
       :name,
       :tag_list,
       :submission_template_id,
@@ -202,7 +211,7 @@ class Api::V1::CollectionsController < Api::V1::BaseController
       :anyone_can_join,
       :joinable_group_id,
       collection_cards_attributes: %i[id order width height row col],
-    )
+    ]
   end
 
   def log_organization_view_activity

--- a/spec/requests/api/v1/collections_controller_spec.rb
+++ b/spec/requests/api/v1/collections_controller_spec.rb
@@ -269,6 +269,8 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
           template: template,
           placement: 'beginning',
           created_by: user,
+          external_id: nil,
+          collection_params: {},
         ).and_return(instance_double)
         post(path, params: params)
       end
@@ -285,6 +287,18 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
           user,
         )
         post(path, params: params)
+      end
+
+      context 'with collection name in params' do
+        let(:params_with_name) do
+          raw_params.merge(collection: { name: 'Awesomeness' }).to_json
+        end
+
+        it 'sets to given name' do
+          post(path, params: params_with_name)
+          template_instance = Collection.find(json['data']['id'])
+          expect(template_instance.name).to eq('Awesomeness')
+        end
       end
 
       context 'as bot user' do


### PR DESCRIPTION
- This is so that we can attach an `external_id` when we create a template instance from C∆