### PR TITLE
Update feedback respondent terms of use copy

### DIFF
--- a/app/javascript/ui/test_collections/TermsQuestion.js
+++ b/app/javascript/ui/test_collections/TermsQuestion.js
@@ -50,6 +50,8 @@ class TermsQuestion extends React.Component {
           different personal data laws and may be less strict than the EU for
           example.
           <br />
+          <br />
+          Only one response per person will be accepted and rewarded.
         </QuestionText>
         <EmojiHolder data-cy="TermsEmojiHolder">
           <EmojiButton


### PR DESCRIPTION
**What**
Add copy about only accepting single response per person.

**Why**
We don't want people answering the same survey multiple times, both to
prevent spam and ensure data quality.

Tickets/Trello Cards:
https://trello.com/c/GWYjGNg8/1816-0-update-respondent-tou-to-cover-duplicate-respondents