### PR TITLE
Calculate days between org creation/adding payment

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -383,6 +383,7 @@ class Organization < ApplicationRecord
     # Should this check against all possible payment methods and not just default?
     payment_method = network_default_payment_method
     return 'No payment method' if payment_method.blank?
+
     (network_default_payment_method.created_at.to_date - self.created_at.to_date).to_i
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -701,9 +701,9 @@ describe Organization, type: :model do
   end
 
   describe '#days_before_payment_added' do
-    let(:organization) { create(:organization, has_payment_method: true, created_at: 2.days.ago) }
+    let(:organization) { create(:organization, has_payment_method: true, created_at: 48.hours.ago) }
     let(:network_organization) { double('network_organization', id: 345) }
-    let(:payment_method) { double('payment_method', id: 234, created_at: Date.today) }
+    let(:payment_method) { double('payment_method', id: 234, created_at: Time.zone.now) }
 
     before do
       allow(organization).to receive(:network_organization).and_return(network_organization)
@@ -715,7 +715,7 @@ describe Organization, type: :model do
 
     context 'when there is a payment method' do
       it 'returns the number of days between creating org and adding payment method' do
-        expect(organization.days_before_payment_added).to eq 1
+        expect(organization.days_before_payment_added).to eq 2
       end
     end
   end


### PR DESCRIPTION
**What**
Add method for calculating days between creating an organization and
when it has a payment method added.

**Why**
Allow us to better understand user behavior.

Tickets/Trello Cards:
https://trello.com/c/gIHZJD5E/1910-track-the-number-of-days-after-org-creation-until-payment-was-added-per-org