### PR TITLE
Fix contact form in test survey response

### DIFF
--- a/app/javascript/stores/ApiStore.js
+++ b/app/javascript/stores/ApiStore.js
@@ -178,16 +178,11 @@ class ApiStore extends jsonapi(datxCollection) {
     }
   }
 
-  async createLimitedUser({ contactInfo, sessionUid }) {
-    try {
-      const res = await this.request('users/create_limited_user', 'POST', {
-        contact_info: contactInfo,
-        session_uid: sessionUid,
-      })
-      return res
-    } catch (e) {
-      trackError(e, { source: 'createLimitedUser' })
-    }
+  createLimitedUser({ contactInfo, sessionUid }) {
+    return this.request('users/create_limited_user', 'POST', {
+      contact_info: contactInfo,
+      session_uid: sessionUid,
+    })
   }
 
   checkCurrentOrg({ id = '', slug = '' } = {}) {

--- a/app/javascript/ui/global/styled/forms.js
+++ b/app/javascript/ui/global/styled/forms.js
@@ -433,6 +433,7 @@ export const CommentForm = styled.form`
 CommentForm.displayName = 'CommentForm'
 
 export const StyledCommentTextarea = styled.div`
+  input,
   textarea {
     resize: none;
     padding: 10px;

--- a/app/javascript/ui/test_collections/RecontactQuestion.js
+++ b/app/javascript/ui/test_collections/RecontactQuestion.js
@@ -9,12 +9,13 @@ import ReturnArrowIcon from '~/ui/icons/ReturnArrowIcon'
 import OkIcon from '~/ui/icons/OkIcon'
 import {
   QuestionText,
-  TextInput,
+  SingleLineInput,
   TextResponseHolder,
   TextEnterButton,
 } from '~/ui/test_collections/shared'
 import styled from 'styled-components'
 import v from '~/utils/variables'
+import trackError from '~/utils/trackError'
 
 const IconHolder = styled.div`
   bottom: 14px;
@@ -57,10 +58,11 @@ class RecontactQuestion extends React.Component {
     const { sessionUid } = this.props
     try {
       const res = await apiStore.createLimitedUser({ contactInfo, sessionUid })
-      if (!res) {
-        throw { errors: ['Contact information invalid'] }
-        return
-      }
+      console.log({ res })
+      // if (!res) {
+      //   throw { errors: ['Contact information invalid'] }
+      //   return
+      // }
       user = res.data
       const { showFeedbackRecontact } = this.state
       this.setState({
@@ -70,7 +72,8 @@ class RecontactQuestion extends React.Component {
         createdUser: user,
       })
     } catch (err) {
-      uiStore.alert(err.errors[0])
+      trackError(err, { source: 'createLimitedUser' })
+      uiStore.alert(err.error[0])
       return
     }
 
@@ -224,12 +227,13 @@ class RecontactQuestion extends React.Component {
           )}
         </div>
         <TextResponseHolder>
-          <TextInput
+          <SingleLineInput
             onChange={this.handleChange}
             value={contactInfo}
             type="questionText"
             placeholder={placeholder}
             data-cy="RecontactTextInput"
+            disabled={submittedContactInfo}
           />
           {submittedContactInfo ? (
             <IconHolder>

--- a/app/javascript/ui/test_collections/shared.js
+++ b/app/javascript/ui/test_collections/shared.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import TextareaAutosize from 'react-autosize-textarea'
 
 import { StyledCommentTextarea } from '~/ui/global/styled/forms'
@@ -71,31 +71,16 @@ export const TextInput = styled(TextareaAutosize)`
 `
 TextInput.displayName = 'TextInput'
 
-export const TestQuestionInput = css`
-  background-color: ${props =>
-    props.editable ? v.colors.primaryMedium : v.colors.primaryDark};
-  border: 0;
-  box-sizing: border-box;
-  color: white;
-  font-family: ${v.fonts.sans};
-  font-size: 1rem;
-  outline: 0;
-  resize: none;
-  padding: 12px 12px 16px 12px;
-  width: 100%;
+export const SingleLineInput = styled.input`
+  color: ${props => props.theme[props.type]};
+  font-family: ${v.fonts.sans} !important;
+  width: calc(100% - 20px);
 
   ::placeholder {
-    color: white !important;
+    color: ${props => props.theme[props.type]} !important;
     opacity: 1;
   }
 `
-
-TestQuestionInput.propTypes = {
-  editable: PropTypes.bool,
-}
-TestQuestionInput.defaultProps = {
-  editable: false,
-}
 
 export const TestQuestionHolder = styled.div`
   background-color: ${props =>


### PR DESCRIPTION
**What**
Make field an input instead of a text area.
Disable input field when information has been submitted.

**Why**
Prevent validation errors caused by users adding newlines when hitting
enter key to submit form.

Tickets/Trello Cards:
https://trello.com/c/6uD7O6pc/1925-some-respondents-saying-they-are-unable-to-add-their-email