### PR TITLE
Include names in collection and item URL slugs

### DIFF
--- a/app/javascript/ui/pages/PageWithApiWrapper.js
+++ b/app/javascript/ui/pages/PageWithApiWrapper.js
@@ -9,6 +9,7 @@ import CollectionPage from '~/ui/pages/CollectionPage'
 import ItemPage from '~/ui/pages/ItemPage'
 import trackError from '~/utils/trackError'
 import routeToLogin from '~/utils/routeToLogin'
+import _ from 'lodash'
 
 @inject('apiStore', 'uiStore')
 @observer
@@ -109,6 +110,17 @@ class PageWithApiWrapper extends React.Component {
       .then(res => {
         if (this.unmounted) return
         const { data } = res
+        const { id } = match.params
+
+        if (id && id.toString() === this.fetchId) {
+          // Update URL so collections and items have slug with id and name
+          history.replaceState(
+            {},
+            data.name,
+            `${data.id}-${_.kebabCase(data.name)}`
+          )
+        }
+
         data.fullyLoaded = true
         this.setState({ data })
       })


### PR DESCRIPTION
**What**
Update URL slug to include collection/item name while navigating app.

**Why**
Give users more context about collection or item that they are viewing
by showing the name in the URL slug.

**Tickets/Trello Cards**:
https://trello.com/c/ervTYdJd/1763-1-add-collection-item-url-slugs