### PR TITLE
Correct logic for user collection links

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -813,8 +813,8 @@ class Collection < ApplicationRecord
     Collection.in_collection(id).where.not(template_id: nil).any?
   end
 
-  def child_of_application_collection?
-    parent.is_a?(Collection::ApplicationCollection)
+  def parent_application_collection
+    parents.find_by(type: 'Collection::ApplicationCollection')
   end
 
   # =================================

--- a/app/workers/link_to_shared_collections_worker.rb
+++ b/app/workers/link_to_shared_collections_worker.rb
@@ -35,8 +35,8 @@ class LinkToSharedCollectionsWorker
   private
 
   def create_link(object, collection)
-    if object.child_of_application_collection?
-      object = object.parent
+    if object.parent_application_collection.present?
+      object = object.parent_application_collection
     end
     CollectionCard::Link.create(
       parent: collection,
@@ -49,8 +49,7 @@ class LinkToSharedCollectionsWorker
   end
 
   def card_order(object, collection)
-    return -1 if object.child_of_application_collection? ||
-                 object.is_a?(Collection::ApplicationCollection)
+    return -1 if object.is_a?(Collection::ApplicationCollection)
     collection.collection_cards.count
   end
 end

--- a/spec/workers/link_to_shared_collections_worker_spec.rb
+++ b/spec/workers/link_to_shared_collections_worker_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe LinkToSharedCollectionsWorker, type: :worker do
       end
     end
 
+    context 'when the link is a child of a child of an application collection' do
+      let!(:application_collection) { create(:application_collection, organization: organization) }
+      let(:child_collection) do
+        create(:collection,
+               parent_collection: application_collection,
+               organization: organization)
+      end
+      let!(:collection_to_link) do
+        create(:collection,
+               parent_collection: child_collection,
+               organization: organization)
+      end
+
+      it 'should add the link at the first position' do
+        link = user.current_shared_collection.collection_cards.first
+        expect(link.collection_id).to eq application_collection.id
+      end
+    end
+
     context 'with multiple users' do
       let(:users_to_add) { create_list(:user, 4, add_to_org: organization) }
 


### PR DESCRIPTION
The logic for this changed various times but this should be the finalized logic:

any item or collection that is under an application collection (like the Creative Difference collection) will have the application collection linked in the first position.