### PR TITLE
Always use HTTP(S) protocol for external links

### DIFF
--- a/__tests__/ui/grid/blankContentTool/LinkCreator.unit.test.js
+++ b/__tests__/ui/grid/blankContentTool/LinkCreator.unit.test.js
@@ -101,7 +101,8 @@ describe('LinkCreator', () => {
       }
       component.state = {
         urlValid: 'link',
-        url: 'https://cnn.com',
+        // if user typed cnn.com, the meta.url should still have a protocol
+        url: 'cnn.com',
         meta,
       }
       component.createLinkItem()

--- a/app/javascript/ui/grid/blankContentTool/LinkCreator.js
+++ b/app/javascript/ui/grid/blankContentTool/LinkCreator.js
@@ -82,7 +82,7 @@ class LinkCreator extends React.Component {
         urlValid: 'image',
       })
     } else {
-      this.setState({ urlValid: false })
+      this.setState({ meta, urlValid: false })
     }
   }
 

--- a/app/javascript/utils/parseURLMeta.js
+++ b/app/javascript/utils/parseURLMeta.js
@@ -34,8 +34,9 @@ const parseURLMeta = async urlStr => {
     const metadata = metaDataParser.getMetadata(doc, url)
     return metadata
   } catch (e) {
-    // will fail w/ 404 if link is invalid
-    return false
+    // will catch a 404 if link is invalid.
+    // we still return a metadata object ensuring "http" prefixed URL
+    return { url }
   }
 }
 


### PR DESCRIPTION
**What**
Use `meta.url` field to set `url` attribute for link card creation.

**Why**
Bugfix for urls like `cnn.com` that would open as a relative path in
Shape, like `https://www.shape.space/ideo/collections/cnn.com`.

Tickets/Trello Cards:
https://trello.com/c/wxt8MZLU/2035-05-link-card-urls-resolving-within-shapespace