### PR TITLE
Don't count users removed from org toward billing

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::UsersController < Api::V1::BaseController
 
   def me
     if user_signed_in? || current_api_token.present?
-      current_user.update_attributes(last_active_at: Time.current)
+      update_user_last_active_at
+
       render jsonapi: current_user, include: [
         :groups,
         organizations: %i[primary_group],
@@ -82,6 +83,16 @@ class Api::V1::UsersController < Api::V1::BaseController
   end
 
   private
+
+  def update_user_last_active_at
+    return if current_user.current_organization_id.nil?
+
+    timestamps = current_user.last_active_at.merge({
+      current_user.current_organization_id.to_s => Time.zone.now
+    })
+
+    current_user.update_attributes(last_active_at: timestamps)
+  end
 
   def load_and_authorize_organization
     # NOTE: friendly.find can cause issues here with numeric slugs e.g. "1", so we check for that

--- a/app/interactors/calculate_organization_active_users.rb
+++ b/app/interactors/calculate_organization_active_users.rb
@@ -18,16 +18,10 @@ class CalculateOrganizationActiveUsers
   def calculate_active_users_count
     # We only want to count activity users have done within this particular org
     # e.g. a user may have logged in recently and been "active" but in a different org
-
-    # TODO: refactor last_active_at to be a json of org_id => timestamp e.g. { "1": timestamp, "22" : timestamp }
-    Activity
-      .joins(:actor)
-      .where(User.arel_table[:status].eq(User.statuses[:active]))
+    User
+      .active
       .where(User.arel_table[:email].not_eq(Organization::SUPER_ADMIN_EMAIL))
-      .where(organization_id: organization.id)
-      .where(Activity.arel_table[:created_at].gt(Organization::RECENTLY_ACTIVE_RANGE.ago))
-      .select(:actor_id)
-      .distinct
+      .where("last_active_at->>'#{organization.id}' > ?", Organization::RECENTLY_ACTIVE_RANGE.ago)
       .count
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -155,6 +155,9 @@ class Organization < ApplicationRecord
     profile = Collection::UserProfile.find_by(user: user, organization: self)
     profile.archive! if profile.present?
 
+    # Remove last_active_at for org they are being removed from
+    timestamps = user.last_active_at.except(self.id.to_s)
+    user.update_columns(last_active_at: timestamps)
     # Set current org as one they are a member of
     # If nil, that is fine as they shouldn't have a current organization
     user.switch_to_organization(user.organizations.first)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@
 #  first_name                  :string
 #  handle                      :string
 #  invitation_token            :string
-#  last_active_at              :datetime
+#  last_active_at              :jsonb
 #  last_name                   :string
 #  last_notification_mail_sent :datetime
 #  last_sign_in_at             :datetime
@@ -506,6 +506,12 @@ class User < ApplicationRecord
 
   def current_terms_accepted?
     terms_accepted && current_org_terms_accepted
+  end
+
+  def last_active_at_in_org(org_id)
+    date_string = last_active_at[org_id.to_s]
+    return if date_string.nil?
+    Time.parse(date_string)
   end
 
   private

--- a/app/services/organization_user_report.rb
+++ b/app/services/organization_user_report.rb
@@ -29,10 +29,10 @@ class OrganizationUserReport
     end
   end
 
-  def self.active_users_in_domain(email: 'ideo.com', within: 3.months)
+  def self.active_users_in_domain(email: 'ideo.com', within: 3.months, id: 1)
     User
       .active
-      .where('last_active_at > ?', within.ago)
+      .where("last_active_at->>'#{id}' > ?", within.ago)
       .where('email LIKE ?', "%#{email}")
   end
 end

--- a/app/services/roles/mass_remove.rb
+++ b/app/services/roles/mass_remove.rb
@@ -105,6 +105,8 @@ module Roles
                 @object.organization.guest_group.can_view?(user)
         @object.organization.remove_user_membership(user)
       end
+      # Recalculate active users after removing people from an organization
+      CalculateOrganizationActiveUsers.call(organization: @object.organization)
     end
 
     def children

--- a/db/migrate/20190815222240_change_last_active_at_to_jsonb.rb
+++ b/db/migrate/20190815222240_change_last_active_at_to_jsonb.rb
@@ -1,0 +1,11 @@
+class ChangeLastActiveAtToJsonb < ActiveRecord::Migration[5.2]
+  def up
+    remove_column :users, :last_active_at
+    add_column :users, :last_active_at, :jsonb, default: {}
+  end
+
+  def down
+    remove_column :users, :last_active_at
+    add_column :users, :last_active_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_02_172427) do
+ActiveRecord::Schema.define(version: 2019_08_15_222240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -574,11 +574,11 @@ ActiveRecord::Schema.define(version: 2019_08_02_172427) do
     t.boolean "show_move_helper", default: true
     t.boolean "show_template_helper", default: true
     t.boolean "mailing_list", default: false
-    t.datetime "last_active_at"
     t.string "phone"
     t.integer "feedback_contact_preference", default: 0
     t.boolean "shape_circle_member", default: false
     t.jsonb "terms_accepted_data", default: {}
+    t.jsonb "last_active_at", default: {}
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token"

--- a/lib/tasks/populate_last_active_at_to_date.rake
+++ b/lib/tasks/populate_last_active_at_to_date.rake
@@ -1,0 +1,18 @@
+namespace :last_active_at do
+  desc 'Populate users with new last_active_at format (now with multiple orgs!)'
+  task populate: :environment do
+      User.active.includes(:organizations).find_each do |user|
+        org_to_timestamps = {}
+        p "Updating organization timestamps for user"
+        user.organizations.each do |org|
+          timestamp = Activity.where(organization_id: org.id, actor_id: user.id).last&.created_at
+          next if timestamp.nil?
+
+          org_to_timestamps[org.id] = timestamp
+        end
+        p "User has these timestamps for these orgs"
+        p org_to_timestamps
+        user.update_columns(last_active_at: org_to_timestamps)
+      end
+  end
+end

--- a/spec/interactors/calculate_organization_active_users_spec.rb
+++ b/spec/interactors/calculate_organization_active_users_spec.rb
@@ -2,20 +2,49 @@ require 'rails_helper'
 
 RSpec.describe CalculateOrganizationActiveUsers, type: :service do
   let(:organization) { create(:organization) }
+  let(:second_organization) { create(:organization) }
   subject(:context) { CalculateOrganizationActiveUsers.call(organization: organization) }
 
   describe '#call' do
     let(:pending_user) do
-      create(:user, :recently_active, current_organization: organization, status: User.statuses[:pending], first_name: 'pending_user')
+      create(:user,
+        :recently_active,
+        current_organization: organization,
+        status: User.statuses[:pending],
+        first_name: 'pending_user',
+        last_active_at: {},
+      )
     end
     let(:deleted_user) do
-      create(:user, :recently_active, current_organization: organization, status: User.statuses[:deleted], first_name: 'deleted_user')
+      create(:user,
+        :recently_active,
+        current_organization: organization,
+        status: User.statuses[:deleted],
+        first_name: 'deleted_user',
+        last_active_at: {},
+      )
     end
     let(:recently_active_user) do
-      create(:user, :recently_active, current_organization: organization, first_name: 'recently_active_user')
+      create(:user,
+        :recently_active,
+        current_organization: organization,
+        first_name: 'recently_active_user',
+        last_active_at: {
+          organization.id => 1.day.ago,
+          second_organization => 1.month.ago,
+        },
+      )
     end
     let(:recently_active_guest_user) do
-      create(:user, :recently_active, current_organization: organization, first_name: 'recently_active_guest_user')
+      create(:user,
+        :recently_active,
+        current_organization: organization,
+        first_name: 'recently_active_guest_user',
+        last_active_at: {
+          organization.id => 1.day.ago,
+          second_organization => 1.month.ago,
+        },
+      )
     end
     let(:not_recently_active_user) { create(:user, first_name: 'not_recently_active_user') }
     let(:not_recently_active_guest_user) { create(:user, first_name: 'not_recently_active_guest_user') }
@@ -29,7 +58,7 @@ RSpec.describe CalculateOrganizationActiveUsers, type: :service do
       not_recently_active_guest_user.add_role(Role::ADMIN, organization.guest_group)
     end
 
-    it 'updates active users count' do
+    it 'updates active users count for a specific organization' do
       expect(context).to be_a_success
       expect(context.organization.active_users_count).to eql(2)
     end

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -25,7 +25,9 @@ describe Api::V1::UsersController, type: :request, json: true, auth: true, creat
 
     it 'updates the users last_active_at timestamp' do
       expect { get(path) }.to change(user, :last_active_at)
-      expect(user.last_active_at).to be_within(1.second).of(Time.current)
+      expect(
+        user.last_active_at_in_org(user.current_organization_id)
+      ).to be_within(1.second).of(Time.current)
     end
 
     it 'returns a 200' do

--- a/spec/services/roles/mass_remove_spec.rb
+++ b/spec/services/roles/mass_remove_spec.rb
@@ -184,6 +184,11 @@ RSpec.describe Roles::MassRemove, type: :service do
             )
             mass_remove.call
           end
+
+          it 'updates the active user count for the organization' do
+            expect(CalculateOrganizationActiveUsers).to receive(:call).with(organization: organization)
+            mass_remove.call
+          end
         end
 
         context 'when the object is a guest group, but user is a primary member' do


### PR DESCRIPTION
**What**
Update active user count after a user is removed from an organization.

**Why**
Prevent overcharging customers for "active" users that were removed
from their organization and thus not using the product.

Tickets/Trello Cards:
https://trello.com/c/gfu644Df/2033-05-if-an-admin-removes-a-user-from-their-organization-they-should-no-longer-count-towards-billing