### PR TITLE
Fix comment button hover state

### DIFF
--- a/app/javascript/ui/global/styled/buttons.js
+++ b/app/javascript/ui/global/styled/buttons.js
@@ -58,14 +58,14 @@ export const CircledIcon = styled.button`
   justify-content: center;
   position: relative;
   width: 32px;
-  ${props =>
-    props.active && `background-color: ${v.colors.commonMedium};`} &:hover {
+  ${props => props.active && `background-color: ${v.colors.commonMedium};`}
+  &:hover {
     background-color: ${v.colors.commonMedium};
   }
 
   .icon {
     height: 20px;
-    width: 20px;
+    width: 32px;
   }
 `
 CircledIcon.displayName = 'StyledCircledIcon'


### PR DESCRIPTION
**What**
Make hover state match the regular icon size

**Why**
Consistency of icon sizes.

Tickets/Trello Cards:
https://trello.com/c/UoLFu8zA/1787-0-hover-state-on-comment-button-in-nav-is-a-squished-oval