### PR TITLE
Make title text items transparent when editing

### DIFF
--- a/app/assets/stylesheets/quill/quill.scss
+++ b/app/assets/stylesheets/quill/quill.scss
@@ -22,15 +22,18 @@
   height: 100%;
   margin: 0px;
   position: relative;
+
   &.ql-disabled {
     .ql-tooltip {
       visibility: hidden;
     }
-    .ql-editor ul[data-checked] > li::before {
+
+    .ql-editor ul[data-checked]>li::before {
       pointer-events: none;
     }
+
     // added this for draggable
-    .ql-editor > * {
+    .ql-editor>* {
       cursor: inherit;
     }
   }
@@ -42,6 +45,7 @@
   overflow-y: hidden;
   position: absolute;
   top: 50%;
+
   p {
     margin: 0;
     padding: 0;
@@ -58,7 +62,8 @@
   text-align: left;
   white-space: pre-wrap;
   word-wrap: break-word;
-  > * {
+
+  >* {
     cursor: text;
   }
 
@@ -81,10 +86,12 @@
   margin-left: -5px;
   width: calc(100% - 50px);
 }
+
 .ql-header {
   display: block;
 }
-.ql-formats > .ql-link {
+
+.ql-formats>.ql-link {
   margin-bottom: 3px;
 }
 

--- a/app/javascript/ui/grid/covers/TextItemCover.js
+++ b/app/javascript/ui/grid/covers/TextItemCover.js
@@ -21,7 +21,8 @@ const StyledPaddedCover = styled(PaddedCardCover)`
     !props.isEditing && props.hasTitleText ? '2px solid black' : 'none'};
   background: ${props =>
     (!props.isEditing && !props.dragging && props.hasTitleText) ||
-    props.isTransparent
+    props.isTransparent ||
+    (props.isEditing && props.hasTitleText)
       ? v.colors.transparent
       : v.colors.white};
 `
@@ -227,6 +228,7 @@ class TextItemCover extends React.Component {
     const { isEditing, hasTitleText, props } = this
     const { isTransparent, dragging } = props
     const content = isEditing ? this.renderEditing() : this.renderDefault()
+
     return (
       <StyledPaddedCover
         data-cy="TextItemCover"


### PR DESCRIPTION
**What**
Make background of text item transparent when using title font.

**Why**
Make editing experience closer to what end result will look like.

Tickets/Trello Cards:
https://trello.com/c/h6mDrTpF/2042-1-background-of-text-cards-should-immediately-become-transparent-when-in-title-mode