### PR TITLE
Make mobile menu search work again

### DIFF
--- a/app/javascript/stores/RoutingStore.js
+++ b/app/javascript/stores/RoutingStore.js
@@ -56,8 +56,11 @@ class RoutingStore extends RouterStore {
       case 'search':
         // `id` means query in this case
         const path = `/${this.slug()}/search`
-        const qs = id ? `?q=${encodeURIComponent(id)}` : ''
-        return `${path}${qs}&${stringifyUrlParams(params)}`
+        const queryString = id ? `?q=${encodeURIComponent(id)}` : ''
+        if (queryString.length > 0) {
+          return `${path}${queryString}&${stringifyUrlParams(params)}`
+        }
+        return path
       case 'admin':
         return '/admin'
       case 'homepage':

--- a/app/javascript/ui/layout/GlobalSearch.js
+++ b/app/javascript/ui/layout/GlobalSearch.js
@@ -105,10 +105,9 @@ class GlobalSearch extends React.Component {
       <div>
         <SearchButton
           background="white"
-          defaultOpen={this.open}
+          defaultOpen={routingStore.pathContains('/search')}
           open={this.open}
           controlled={true}
-          focused={routingStore.pathContains('/search')}
           value={this.searchText}
           onChange={this.handleTextChange}
           onClear={this.clearSearch}


### PR DESCRIPTION
**What**
Adjust generated URL path to go to `/search` if no query params (which
includes when a user clicks "Search" on mobile).

**Why**
Clicking the "Search" option in the mobile menu dropdown sent users in
a loop  without letting them actually search.

Tickets/Trello Cards:
https://trello.com/c/6zl9YXXp/1999-1-search-broken-on-mobile