### PR TITLE
Upgrade react to use react profiler

### DIFF
--- a/config/webpack/custom/react-profiler.js
+++ b/config/webpack/custom/react-profiler.js
@@ -1,8 +1,0 @@
-module.exports = {
-  resolve: {
-      alias: {
-        'react-dom$': 'react-dom/profiling',
-        'scheduler/tracing': 'scheduler/tracing-profiling',
-      }
-    }
-}

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -5,7 +5,6 @@ const { environment } = require('@rails/webpacker')
 const path = require('path')
 const { castArray, identity, flow, mapValues } = require('lodash/fp')
 const SentryWebpackPlugin = require('@sentry/webpack-plugin');
-const reactProfiler = require('./custom/react-profiler')
 
 const DEV = process.env.RAILS_ENV === 'development'
 const PROD = process.env.SHAPE_APP === 'production'
@@ -110,13 +109,6 @@ const addSentryWebpack = env => {
   return env
 }
 
-const addReactProfiler = env => {
-    if (DEV) {
-      env.config.merge(reactProfiler)
-      return env
-    }
-}
-
 const updateEnvironment = flow(
   DEV ? addReactHotLoader : identity,
   addReactGlobal,
@@ -124,7 +116,6 @@ const updateEnvironment = flow(
   addReactSVGLoader,
   addTypescriptLoader,
   addIdeoSSOExternal,
-  addReactProfiler,
   process.env.ANALYZE ? addBundleAnalyzerPlugin : identity
 )
 


### PR DESCRIPTION
### Summary
Added react profiler custom config based on [webpacker's docs](https://github.com/rails/webpacker/blob/master/docs/webpack.md#configuration), and this [gist](https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977#webpack-4).

Per this [gist](https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977#webpack-4):
> React DOM automatically supports profiling in development mode for v16.5+, but since profiling adds some small additional overhead it is opt-in for production mode. This gist explains how to opt-in.

### Other info
Please see React **16.3** [ changelog](https://github.com/facebook/react/blob/master/CHANGELOG.md#1663-november-12-2018) for more info.