### PR TITLE
add test debug script to use chrome debugger when writing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "cypress-ci": "./node_modules/.bin/cypress run",
     "lint": "./node_modules/.bin/eslint",
     "styleguide": "yarn styleguidist server",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand --watch"
   },
   "engines": {
     "node": "^8.15.0",


### PR DESCRIPTION
**Summary**
Leverages the chrome debugger to add breakpoints in code using `debugger`.

See: https://artsy.github.io/blog/2018/08/24/How-to-debug-jest-tests/