### PR TITLE
Allow dragging cards to first/last position

### DIFF
--- a/__tests__/ui/grid/CollectionGrid.unit.test.js
+++ b/__tests__/ui/grid/CollectionGrid.unit.test.js
@@ -65,4 +65,37 @@ describe('CollectionGrid', () => {
     // it does re-render with a change to cardProperties
     expect(wrapper.find('MovableGridCard').length).toBe(1)
   })
+
+  describe('calculateOrderForMovingCard', () => {
+    describe('moving to first card position (0 index)', () => {
+      it('returns an integer', () => {
+        const locationOfTargetPlaceholder = -0.5
+        expect(
+          wrapper
+            .instance()
+            .calculateOrderForMovingCard(locationOfTargetPlaceholder, 0)
+        ).toBe(0)
+        expect(
+          wrapper
+            .instance()
+            .calculateOrderForMovingCard(locationOfTargetPlaceholder, 1)
+        ).toBe(1)
+      })
+    })
+    describe('moving to last card position in collection', () => {
+      it('returns an integer', () => {
+        const locationOfTargetPlaceholder = 3.5
+        expect(
+          wrapper
+            .instance()
+            .calculateOrderForMovingCard(locationOfTargetPlaceholder, 0)
+        ).toBe(4)
+        expect(
+          wrapper
+            .instance()
+            .calculateOrderForMovingCard(locationOfTargetPlaceholder, 1)
+        ).toBe(5)
+      })
+    })
+  })
 })

--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -551,11 +551,10 @@ class Collection extends SharedRecordMixin(BaseRecord) {
     _.each(updates, update => {
       updatesByCardId[update.card.id] = update
     })
-    let minOrder = _.minBy(updates, 'order')
-    minOrder = minOrder ? minOrder.order : 0
-    let maxOrder = _.maxBy(updates, 'order')
-    maxOrder = maxOrder ? maxOrder.order : 0
-    const moveOrder = _.min([minOrder, maxOrder])
+    const orders = _.map(updates, update => update.order)
+    const minOrder = _.min(orders)
+    const maxOrder = _.max(orders)
+    // min...max is range of cards you are moving
 
     // Apply all updates to in-memory cards
     _.each(this.collection_cards, card => {
@@ -567,9 +566,9 @@ class Collection extends SharedRecordMixin(BaseRecord) {
         _.forEach(allowedAttrs, (value, key) => {
           card[key] = value
         })
-      } else if (moveOrder && card.order >= moveOrder) {
+      } else if (card.order >= minOrder) {
         // make sure this card gets bumped out of the way of our moving ones
-        card.order += maxOrder
+        card.order += maxOrder + 1
       }
       // force the grid to immediately observe that things have changed
       card.updated_at = new Date()

--- a/app/javascript/ui/grid/CollectionGrid.js
+++ b/app/javascript/ui/grid/CollectionGrid.js
@@ -268,6 +268,10 @@ class CollectionGrid extends React.Component {
     })
   }
 
+  calculateOrderForMovingCard = (order, index) => {
+    return Math.ceil(order) + index
+  }
+
   onDragOrResizeStop = (cardId, dragType) => {
     const { hoveringOver, cards } = this.state
     const placeholder = _.find(cards, { cardType: 'placeholder' }) || {}
@@ -333,7 +337,7 @@ class CollectionGrid extends React.Component {
         // and API_batchUpdateCards will properly set/reorder it amongst the collection
         const sortedCards = _.sortBy(movingCards, 'order')
         _.each(sortedCards, (card, idx) => {
-          const sortedOrder = order + (idx + 1) * 0.1
+          const sortedOrder = this.calculateOrderForMovingCard(order, idx)
           updates.push({
             card,
             order: sortedOrder,
@@ -540,7 +544,7 @@ class CollectionGrid extends React.Component {
         cards,
         c => _.includes(rowPortion, c.id) && c.position.y === row
       )
-      let near = _.last(cardsInRow)
+      let near = _.last(_.sortBy(cardsInRow, 'order'))
       if (!near && row > 0) {
         // there is the case where the "nearest" card is sticking down from the previous row
         // [ 1  1  2  3 ]


### PR DESCRIPTION
**What**
Allow dragging cards from right to left to position 1 to position 0.
Allow dragging cards from left to right of position X to last position.

**Why**
Allow users to move cards to first and last position without having to
make multiple drag moves.

**Trello Cards/Tickets**:
https://trello.com/c/PowoT9QT/2082-cannot-drag-from-right-to-left-text-item-in-position-1-second-item-to-position-0-same-thing-happens-with-last-position