### PR TITLE
Allow globalize attrs on controller endpoints

### DIFF
--- a/app/controllers/api/v1/collection_cards_controller.rb
+++ b/app/controllers/api/v1/collection_cards_controller.rb
@@ -353,7 +353,7 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
         external_id
         cover_type
         submissions_enabled
-      ],
+      ].concat(Collection.globalize_attribute_names),
       item_attributes: [
         :id,
         :type,
@@ -398,7 +398,7 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
             column
           ],
         ],
-      ],
+      ].concat(Item.globalize_attribute_names),
     ]
   end
 

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -232,7 +232,7 @@ class Api::V1::CollectionsController < Api::V1::BaseController
       :cover_type,
       :default_group_id,
       collection_cards_attributes: %i[id order width height row col],
-    ]
+    ].concat(Collection.globalize_attribute_names)
   end
 
   def log_organization_view_activity

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -87,19 +87,21 @@ class Api::V1::ItemsController < Api::V1::BaseController
 
   def item_params
     params.require(:item).permit(
-      :type,
-      :name,
-      :external_id,
-      :content,
-      { data_content: {} },
-      :url,
-      :image,
-      :archived,
-      :tag_list,
-      :thumbnail_url,
-      :legend_item_id,
-      :legend_search_source,
-      filestack_file_attributes: Item.filestack_file_attributes_whitelist,
+      [
+        :type,
+        :name,
+        :external_id,
+        :content,
+        { data_content: {} },
+        :url,
+        :image,
+        :archived,
+        :tag_list,
+        :thumbnail_url,
+        :legend_item_id,
+        :legend_search_source,
+        filestack_file_attributes: Item.filestack_file_attributes_whitelist,
+      ].concat(Item.globalize_attribute_names),
     )
   end
 

--- a/spec/requests/api/v1/collection_cards_controller_spec.rb
+++ b/spec/requests/api/v1/collection_cards_controller_spec.rb
@@ -432,6 +432,39 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
         expect(item['attributes']['url']).to eq('https://www.youtube.com/watch?v=4r7wHMg5Yjg')
       end
     end
+
+    context 'with translated attributes' do
+      let(:params_with_translated_attrs) do
+        json_api_params(
+          'collection_cards',
+          order: 1,
+          parent_id: collection.id,
+          item_attributes: {
+            type: 'Item::TextItem',
+            name: 'Something great',
+            translated_name_es: 'Algo genial',
+            content: "Isn't this a cool widget?",
+            translated_content_es: '¿No es este un widget genial?',
+          },
+        )
+      end
+
+      it 'returns a 200' do
+        post(path, params: params_with_translated_attrs)
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns item with attrs' do
+        post(path, params: params_with_translated_attrs)
+        json_item = json_included_objects_of_type('items').first
+        expect(json_item['attributes']['name']).to eq('Something great')
+        expect(json_item['attributes']['content']).to eq("Isn't this a cool widget?")
+
+        item = Item.find(json_item['id'])
+        expect(item.translated_name_es).to eq('Algo genial')
+        expect(item.translated_content_es).to eq('¿No es este un widget genial?')
+      end
+    end
   end
 
   describe 'PATCH #archive' do


### PR DESCRIPTION
- Allow us to send translated content to the API endpoints.