### PR TITLE
subtitle hotfix

### DIFF
--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -987,6 +987,14 @@ class Collection extends SharedRecordMixin(BaseRecord) {
     return cover.hardcoded_subtitle || cover.text
   }
 
+  get subtitleHidden() {
+    const { cover } = this
+    if (cover && cover.subtitle_hidden) {
+      return cover
+    }
+    return false
+  }
+
   // NOTE: this is only used as a Cypress test method, to simulate card resizing
   API_updateCard({ card, updates, undoMessage } = {}) {
     // this works a little differently than the typical "undo" snapshot...

--- a/app/javascript/ui/grid/CardCoverEditor.js
+++ b/app/javascript/ui/grid/CardCoverEditor.js
@@ -148,7 +148,7 @@ class CardCoverEditor extends React.Component {
       if (
         record.name === this.cardTitle &&
         record.subtitle === this.hardcodedSubtitle &&
-        record.cover.subtitle_hidden === this.subtitleHidden
+        record.subtitleHidden === this.subtitleHidden
       ) {
         return
       }
@@ -288,10 +288,10 @@ class CardCoverEditor extends React.Component {
     const { card, uiStore } = this.props
     const { id } = card
     const { record } = card
-    const { name, cover } = record
+    const { name } = record
     this.cardTitle = name || record.url
     this.hardcodedSubtitle = record.subtitle
-    this.subtitleHidden = cover.subtitle_hidden
+    this.subtitleHidden = record.subtitleHidden
     ev.preventDefault()
     this.populateAllOptions()
     uiStore.setEditingCardCover(id)


### PR DESCRIPTION
hotfix: `undefined` value for `subtitle_hidden` causes app to error out when editing link cards, etc.