### PR TITLE
Allow viewers to highlight text item content

### DIFF
--- a/__tests__/ui/grid/covers/__snapshots__/TextItemCover.unit.test.js.snap
+++ b/__tests__/ui/grid/covers/__snapshots__/TextItemCover.unit.test.js.snap
@@ -21,6 +21,7 @@ exports[`TextItemCover renders snapshot 1`] = `
   >
     <Quill
       modules={Object {}}
+      onChangeSelection={[Function]}
       readOnly={true}
       theme={null}
       value={

--- a/app/javascript/ui/grid/covers/TextItemCover.js
+++ b/app/javascript/ui/grid/covers/TextItemCover.js
@@ -205,6 +205,8 @@ class TextItemCover extends React.Component {
         this.quillEditor = c
       },
       readOnly: true,
+      onChangeSelection: (range, selection, editor) =>
+        console.log(range, selection, editor),
       theme: null,
     }
 

--- a/app/javascript/ui/grid/shared.js
+++ b/app/javascript/ui/grid/shared.js
@@ -232,19 +232,19 @@ export const StyledGridCardInner = styled.div`
     `
   overflow: hidden;
   `} z-index: 1;
-  /*
-  // related to userSelectHack from Rnd / Draggable
-  // disable blue text selection on Draggables
-  // https://github.com/bokuweb/react-rnd/issues/199
-  */
-  *::selection {
-    background: transparent;
-  }
-
   ${props =>
     !props.isText &&
     `
-      /*disable text highlighting*/
+      /*
+      // related to userSelectHack from Rnd / Draggable
+      // disable blue text selection on Draggables
+      // https://github.com/bokuweb/react-rnd/issues/199
+
+      // TODO: always disable this, even for text, while anything is being dragged?
+      */
+      *::selection {
+        background: transparent;
+      }
       user-select: none;
     `}
 

--- a/app/javascript/ui/items/RealtimeTextItem.js
+++ b/app/javascript/ui/items/RealtimeTextItem.js
@@ -84,9 +84,7 @@ const StyledContainer = styled.div`
       position: fixed;
       z-index: 10000;
     }
-  `} *::selection {
-    background: highlight !important;
-  }
+  `}
 `
 
 @observer


### PR DESCRIPTION
https://trello.com/c/f2QNTY5D/2125-1-highlighting-text-as-a-viewer

__Why:__
We must allow users to highlight text in order to comment on specific
parts of a given text item.

__This change addresses the need by:__
* Remove transparency styling that hid user selections when dragging

__Known side effects:__
* You can accidentally highlight collection title when selecting text