### PR TITLE
Fix TextItem paste

### DIFF
--- a/app/javascript/ui/global/QuillClipboard.js
+++ b/app/javascript/ui/global/QuillClipboard.js
@@ -1,20 +1,45 @@
 import Quill from 'quill'
-const Clipboard = Quill.import('modules/clipboard')
-const Delta = Quill.import('delta')
+import Delta from 'quill-delta'
 
+const Clipboard = Quill.import('modules/clipboard')
+
+// convert pasting contents to plain text: https://stackoverflow.com/a/51255601
+// mostly adapted from original onPaste method: https://github.com/quilljs/quill/blob/v1.3.6/modules/clipboard.js
 class QuillClipboard extends Clipboard {
-  // convert pasting contents to plain text: https://stackoverflow.com/a/51255601
+  constructor(quill, options) {
+    super(quill, options)
+    const headers = ['H3', 'H4', 'H6']
+    headers.forEach(header => {
+      this.addMatcher(header, this.remapUnsupportedHeaderToH2)
+    })
+  }
+
+  remapUnsupportedHeaderToH2(node, delta) {
+    delta.map(op => {
+      if (!op.attributes) op.attributes = {}
+      op.attributes.header = 2
+      return op
+    })
+    return delta
+  }
+
   onPaste(e) {
-    e.preventDefault() // this will call the parent class onPaste
-    const range = this.quill.getSelection()
+    e.preventDefault() // this will prevent the parent class onPaste
+    const { quill } = this
+    const range = quill.getSelection()
+    const html = e.clipboardData.getData('text/html')
     const text = e.clipboardData.getData('text/plain')
-    const delta = new Delta()
-      .retain(range.index)
-      .delete(range.length)
-      .insert(text)
-    this.quill.updateContents(delta, Quill.sources.USER)
-    this.quill.setSelection(delta.length() - range.length, Quill.sources.SILENT)
-    this.quill.scrollIntoView()
+    setTimeout(() => {
+      let newDelta = this.convert(html)
+      if (!newDelta.ops.length) {
+        newDelta = new Delta().insert(text)
+      }
+      const delta = new Delta().retain(range.index).concat(newDelta)
+
+      quill.updateContents(delta, Quill.sources.USER)
+      quill.setSelection(delta.length(), Quill.sources.SILENT)
+      quill.scrollIntoView()
+    }, 1)
   }
 }
 


### PR DESCRIPTION
**Summary**
Overrides quill clipboard module to only paste plaintext. This is not a full fix, but open to discussion as to how we'd want to approach formatting while pasting. Perhaps we can apply custom formatting for the formats that we support.