### PR TITLE
Fix dupe org collections appearing in my collection

### DIFF
--- a/app/workers/link_to_shared_collections_worker.rb
+++ b/app/workers/link_to_shared_collections_worker.rb
@@ -14,6 +14,11 @@ class LinkToSharedCollectionsWorker
         # Don't create any links if object was created by user
         next if object.try(:created_by_id) == entity.id
 
+        if within_application_collection?(object)
+          # If linking a C∆ collection, only share the org collection
+          object = object.parent_application_collection.collections.first
+        end
+
         org_id = object.organization_id
         if entity.is_a?(User)
           shared = entity.current_shared_collection(org_id)
@@ -36,13 +41,15 @@ class LinkToSharedCollectionsWorker
 
   private
 
+  def within_application_collection?(object)
+    object.respond_to?(:parent_application_collection) &&
+      object.parent_application_collection.present?
+  end
+
   def create_link(object, collection)
     width = 1
     height = 1
-    if object.respond_to?(:parent_application_collection) &&
-       object.parent_application_collection.present?
-      # link to the org collection within the root application collection
-      object = object.parent_application_collection.collections.first
+    if within_application_collection?(object)
       width = 3
       height = 2
     end


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Two copies of the Org collection cover can appear in "My Collection" when being shared C∆ content.](https://trello.com/c/osZogCgf/2339-two-copies-of-the-org-collection-cover-can-appear-in-my-collection-when-being-shared-c%E2%88%86-content)