### PR TITLE
Update Shape marketing page styling

### DIFF
--- a/app/javascript/ui/global/styled/marketing.js
+++ b/app/javascript/ui/global/styled/marketing.js
@@ -389,6 +389,7 @@ export const MarketingShapeLogo = styled.img.attrs({
 MarketingShapeLogo.displayName = 'StyledMarketingShapeLogo'
 
 const space = [0, 8, 16, 32, 64]
+// These breakpoints are based on REMs, e.g., 52*16 = 832px
 const breakpoints = [40, 52, 64]
 
 export function MarketingFlex(props) {

--- a/app/javascript/ui/marketing/MarketingMenu.js
+++ b/app/javascript/ui/marketing/MarketingMenu.js
@@ -280,7 +280,7 @@ class MarketingMenu extends React.PureComponent {
 
   render() {
     const { width } = this.state
-    const isMobile = width <= v.responsive.smallBreakpoint
+    const isMobile = width <= v.responsive.medBreakpoint
 
     return (
       <MenuWrapper>

--- a/app/javascript/ui/marketing/Stats.js
+++ b/app/javascript/ui/marketing/Stats.js
@@ -155,7 +155,13 @@ const Stats = props => (
       </Box>
     </StatsBannerImages>
     <MarketingFlex justify="center" mt={25}>
-      <Box style={{ maxWidth: 1200 }} flex w={1} justify="space-between">
+      <Box
+        style={{ maxWidth: 1200 }}
+        flex
+        w={1}
+        align="flex-start"
+        justify="space-between"
+      >
         {props.stats.map((stat, index) => (
           <Stat
             key={index.toString()}


### PR DESCRIPTION
https://trello.com/c/ufJ8SJkE/2212-shape-and-creative-difference-marketing-site-design-tweaks
Use new breakpoint for navbar collapse without links/logo jumbling up
* `variables.js` pixel breakpoints differ from Reflexbox REM breakpoints

Adjust stat header and subtitle alignment
* Use flex-start so items align to top of flex box