### PR TITLE
Allow tooltip to display without a date

### DIFF
--- a/app/javascript/ui/global/charts/ChartUtils.js
+++ b/app/javascript/ui/global/charts/ChartUtils.js
@@ -57,8 +57,10 @@ export const chartDomainForDatasetValues = ({ values, maxDomain }) => {
 
 export const emojiTooltipText = datum => `${datum.value}`
 
-export const dateTooltipText = datum =>
-  `${datum.value} on ${utcMoment(datum.date).format('l')}`
+export const dateTooltipText = datum => {
+  if (!datum.date) return datum.value
+  return `${datum.value} on ${utcMoment(datum.date).format('l')}`
+}
 
 export const advancedTooltipText = ({
   datum,


### PR DESCRIPTION
Fix so that we can have line charts without a date value.