### PR TITLE
Add price per response column to feedback admin UI

### DIFF
--- a/__js_test_config/mocks/data.js
+++ b/__js_test_config/mocks/data.js
@@ -47,8 +47,8 @@ export const fakeTextItemAttrs = {
   parent_collection_card: { ...fakeCollectionCard },
 }
 
-export const fakeQuillOp = {insert: "hello world \n"}
-export const fakeQuillData = {ops: [fakeQuillOp]}
+export const fakeQuillOp = { insert: 'hello world \n' }
+export const fakeQuillData = { ops: [fakeQuillOp] }
 
 export const fakeAreaChartDataset = {
   identifier: 'question',
@@ -143,7 +143,7 @@ export const fakeDatasetAttrs = {
   test_collection_id: null,
   timeframe: 'ever',
   total: 1,
-  tiers: []
+  tiers: [],
 }
 
 export const fakeDataset = {
@@ -525,7 +525,7 @@ export const fakeComment = {
   created_at: new Date('2019-05-09T03:18:00'),
   updated_at: new Date('2019-05-09T03:18:00'),
   API_fetchReplies: jest.fn().mockReturnValue(Promise.resolve({})),
-  expandAndFetchReplies: jest.fn().mockReturnValue(Promise.resolve({}))
+  expandAndFetchReplies: jest.fn().mockReturnValue(Promise.resolve({})),
 }
 export const fakeThread = {
   id: '1',
@@ -587,6 +587,7 @@ export const fakeTestAudience = {
   audience: fakeAudience,
   sample_size: 12,
   num_completed_responses: 6,
+  price_per_response: 3.75,
 }
 export const fakeTestCollection = {
   id: '1',

--- a/__tests__/ui/admin/AdminFeedback.unit.test.js
+++ b/__tests__/ui/admin/AdminFeedback.unit.test.js
@@ -37,21 +37,26 @@ describe('AdminFeedback', () => {
       expect(wrapper.find('FeedbackRow').length).toEqual(1)
     })
 
+    // TODO: redo this using data selectors
+    // doing it by index is brittle, re: UI changes
     it('shows audience data for each test', () => {
       const audienceRowItems = wrapper.find('AudienceRowItem')
-      expect(audienceRowItems.length).toEqual(4)
+      expect(audienceRowItems.length).toEqual(5)
 
       const audienceName = audienceRowItems.at(0)
       expect(audienceName.html()).toContain(fakeAudience.name)
 
-      const audienceSampleSize = audienceRowItems.at(1)
+      const audiencePricePerResponse = audienceRowItems.at(1)
+      expect(audiencePricePerResponse.html()).toContain('$3.75')
+
+      const audienceSampleSize = audienceRowItems.at(2)
       expect(audienceSampleSize.html()).toContain(fakeTestAudience.sample_size)
 
       // TODO: wire up "Sourced from INA" column to real data
-      const inaSourcedCount = audienceRowItems.at(2)
+      const inaSourcedCount = audienceRowItems.at(3)
       expect(inaSourcedCount.html()).toContain(0)
 
-      const audienceResponseCount = audienceRowItems.at(3)
+      const audienceResponseCount = audienceRowItems.at(4)
       expect(audienceResponseCount.html()).toContain(
         fakeTestAudience.num_completed_responses
       )

--- a/app/javascript/ui/admin/AdminFeedback.js
+++ b/app/javascript/ui/admin/AdminFeedback.js
@@ -236,7 +236,7 @@ class AdminFeedback extends React.Component {
 
               return (
                 <React.Fragment key={testAudience.id}>
-                  <AudienceRowItem item xs={5}>
+                  <AudienceRowItem item xs={4}>
                     <AudienceWrapper align="center">
                       <div style={audienceNameStyle}>
                         {testAudience.audience.name}
@@ -291,9 +291,14 @@ class AdminFeedback extends React.Component {
                     </AudienceWrapper>
                   </AudienceRowItem>
                   <AudienceRowItem item xs={2}>
+                    <Flex justify="flex-end">
+                      ${testAudience.price_per_response}
+                    </Flex>
+                  </AudienceRowItem>
+                  <AudienceRowItem item xs={2}>
                     <Flex justify="flex-end">{testAudience.sample_size}</Flex>
                   </AudienceRowItem>
-                  <AudienceRowItem item xs={3}>
+                  <AudienceRowItem item xs={2}>
                     <Flex justify="flex-end">0</Flex>
                   </AudienceRowItem>
                   <AudienceRowItem item xs={2}>
@@ -401,13 +406,16 @@ class AdminFeedback extends React.Component {
                 <Flex column>
                   <Heading3>Audience(s)</Heading3>
                   <Grid container>
-                    <Grid item xs={5}>
+                    <Grid item xs={4}>
                       <SubHeading>Audience Name</SubHeading>
+                    </Grid>
+                    <Grid item xs={2}>
+                      <SubHeading>$/Response</SubHeading>
                     </Grid>
                     <Grid item xs={2}>
                       <SubHeadingRight>n Requested</SubHeadingRight>
                     </Grid>
-                    <Grid item xs={3}>
+                    <Grid item xs={2}>
                       <SubHeadingRight>Sourced from INA</SubHeadingRight>
                     </Grid>
                     <Grid item xs={2}>


### PR DESCRIPTION
https://trello.com/c/feNYKuEW/2210-05-ideo-admin-has-a-response-column

__Why:__
* Show price per response ($/response) so admins know the price of each
response for a given test

__This change addresses the need by:__
* Add a column and an accompanying header to existing table UI