### PR TITLE
Make sure reindexing is always enabled

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,6 +15,7 @@ default_schedule: &default_schedule
   searchkick_reindex_worker:
     every: '1m'
     class: SearchkickReindexWorker
+    enabled: true # always enabled to ensure records are indexed
   notification_mention_mailer:
     every: '5m'
     class: NotificationMentionMailerWorker


### PR DESCRIPTION
We discovered that many of the collections and items in the C∆ dashboard weren't indexed, and it was because indexing was disabled on the API server.