### PR TITLE
Fix audience info button alignment on IE11

### DIFF
--- a/app/javascript/ui/test_collections/AudienceSettings/AudienceCheckbox.js
+++ b/app/javascript/ui/test_collections/AudienceSettings/AudienceCheckbox.js
@@ -9,15 +9,24 @@ import {
 import { Checkbox, LabelContainer } from '~/ui/global/styled/forms'
 import InfoIcon from '~/ui/icons/InfoIcon'
 import styled from 'styled-components'
+import v from '~/utils/variables'
 
 const StyledInfoIconWrapper = styled.span`
-  width: 8%;
   opacity: 0.5;
-  transform: translateY(1px);
+  margin-top: 1rem;
+
   &:hover {
     opacity: 1;
   }
-  float: right;
+
+  @media only screen and (max-width: ${v.responsive.medBreakpoint}px) {
+    opacity: 1; // Make full opacity because there's no hover on mobile
+  }
+
+  span {
+    width: 1rem;
+    height: 1rem;
+  }
 `
 
 const AudienceCheckbox = ({
@@ -48,25 +57,23 @@ const AudienceCheckbox = ({
           label={
             <div>
               <div style={{ maxWidth: '582px', paddingTop: '15px' }}>
-                <StyledLabelText>
-                  {name}
-                  {!global_default && (
-                    <StyledInfoIconWrapper
-                      onClick={e => {
-                        e.preventDefault()
-                        openAudienceMenu(audience)
-                      }}
-                      className="audienceLabel"
-                    >
-                      <InfoIcon />
-                    </StyledInfoIconWrapper>
-                  )}
-                </StyledLabelText>
+                <StyledLabelText>{name}</StyledLabelText>
               </div>
             </div>
           }
         />
       </StyledRowFlexItem>
+      {!global_default && (
+        <StyledInfoIconWrapper
+          onClick={e => {
+            e.preventDefault()
+            openAudienceMenu(audience)
+          }}
+          className="audienceLabel"
+        >
+          <InfoIcon />
+        </StyledInfoIconWrapper>
+      )}
     </StyledRowFlexParent>
   )
 }

--- a/app/javascript/ui/test_collections/AudienceSettings/styled.js
+++ b/app/javascript/ui/test_collections/AudienceSettings/styled.js
@@ -32,9 +32,6 @@ StyledRowFlexParent.defaultProps = {
 // flex-grow, flex-shrink and flex-basis combined
 const StyledRowFlexItem = styled(Box)`
   width: 250px;
-  @media only screen and (max-width: ${v.responsive.medBreakpoint}px) {
-    /* width: 100px; */
-  }
 `
 
 const StyledRowFlexCell = styled(StyledRowFlexItem)`


### PR DESCRIPTION
__Why:__
* Icon was pushing audiences down, resulting in misalignment

__This change addresses the need by:__
* Moving icon outside of checkbox label

### Images
[Before image](https://dev.shape.space/ideo/items/57269-audience-info-button-misaligned)

[After image](https://dev.shape.space/ideo/items/57270-fixed-audience-info-icon-alignment)