### PR TITLE
Update Shape marketing CTA buttons with ids for GA

### DIFF
--- a/app/javascript/ui/marketing/Pricing.js
+++ b/app/javascript/ui/marketing/Pricing.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { Box } from 'reflexbox'
 import v from '~/utils/variables'
+import { kebabCase } from 'lodash'
 
 import {
   MarketingH1Bold,
@@ -120,7 +121,11 @@ const Description = styled(MarketingContent)`
  */
 
 const PriceCard = props => {
-  const { title, price, price_unit, button, description } = props
+  const { pageName, title, price, price_unit, button, description } = props
+  const buttonId = [pageName, title, button.text]
+    .map(string => kebabCase(string))
+    .join('-')
+
   return (
     <PriceCardBase>
       <MarketingFlex justify="center" px={40} py={40}>
@@ -138,7 +143,11 @@ const PriceCard = props => {
             <div dangerouslySetInnerHTML={{ __html: price_unit }} />
           </Unit>
           <Box mt={[0, 0, 0]} mb={[20, 20, 20]} w={[1, 1, 1]}>
-            <CTAButton variant={'solid-yellow'} href={button.link}>
+            <CTAButton
+              variant={'solid-yellow'}
+              href={button.link}
+              id={buttonId}
+            >
               {button.text}
             </CTAButton>
           </Box>
@@ -151,6 +160,7 @@ const PriceCard = props => {
   )
 }
 PriceCard.propTypes = {
+  pageName: PropTypes.string,
   title: PropTypes.string.isRequired,
   price: PropTypes.number,
   price_unit: PropTypes.string.isRequired,

--- a/app/javascript/ui/pages/MarketingProductPage.js
+++ b/app/javascript/ui/pages/MarketingProductPage.js
@@ -112,9 +112,10 @@ class MarketingProductPage extends React.Component {
               <MarketingFlex align="center" justify="center" wrap w={1}>
                 <Box w={1} justify="center">
                   <ScrollElement name="ContentAnchor" />
-                  {this.sortedBlocks.map((block, i) => (
+                  {this.sortedBlocks.map((block, index) => (
                     <ContentBlock
-                      order={i + 1}
+                      key={index}
+                      order={index + 1}
                       title={block.title}
                       content={block.content}
                       imageUrl={block.imageUrl}


### PR DESCRIPTION
Ticket ID TBD
__Why:__
* Add ids so marketing team can connect with Google tag manager

__This change addresses the need by:__
* Follow C∆ style of kebab-case concatenated ids on CTAs