### PR TITLE
Update graphs upon new survey response completion

### DIFF
--- a/app/workers/create_survey_response_alias_collection_worker.rb
+++ b/app/workers/create_survey_response_alias_collection_worker.rb
@@ -28,6 +28,11 @@ class CreateSurveyResponseAliasCollectionWorker
   def ping_results_collection
     # real-time update any graphs, etc.
     master_test_results_collection.touch
+    Collection::TestResultsCollection.in_collection(master_test_results_collection).each do |collection|
+      collection.touch
+      CollectionUpdateBroadcaster.call(collection)
+    end
+
     CollectionUpdateBroadcaster.call(master_test_results_collection)
   end
 

--- a/spec/workers/create_survey_response_alias_collection_worker_spec.rb
+++ b/spec/workers/create_survey_response_alias_collection_worker_spec.rb
@@ -45,7 +45,18 @@ RSpec.describe CreateSurveyResponseAliasCollectionWorker, type: :worker do
     it 'updates master TestResultsCollection collection' do
       prev_updated_at = test_results_collection.updated_at
       subject.perform(survey_response.id)
+
       expect(test_results_collection.reload.updated_at).to be > prev_updated_at
+    end
+
+    it 'updates test result collections inside the master TestResultsCollection collection' do
+      prev_updated_at = test_results_collection.updated_at
+      collections_to_update = Collection::TestResultsCollection.in_collection(test_results_collection)
+      subject.perform(survey_response.id)
+
+      collections_to_update.each do |collection|
+        expect(collection.updated_at > prev_updated_at).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/BrEpEak3/2272-when-a-new-survey-response-is-received-the-graphs-data-arent-necessarily-updated

Update test results collections when a new survey response is completed

Fixes issue where data charts in test result collections that were not
the top level one wouldn't update when a survey response was completed.