### PR TITLE
Add collection filter back to submissions collection

### DIFF
--- a/app/javascript/ui/filtering/CollectionFilter.js
+++ b/app/javascript/ui/filtering/CollectionFilter.js
@@ -3,11 +3,31 @@ import { Flex } from 'reflexbox'
 import { computed, observable, runInAction } from 'mobx'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
 import pluralize from 'pluralize'
+import styled from 'styled-components'
 
 import { apiStore, uiStore } from '~/stores'
 import FilterBar from './FilterBar'
-import FilterMenu from './FilterMenu'
+import FilterMenu, { FilterIconHolder } from './FilterMenu'
 import FilterSearchModal from './FilterSearchModal'
+import v from '~/utils/variables'
+
+export const SubmissionsFilterPositioner = styled.div`
+  left: 0;
+  position: absolute;
+  right: 215px;
+  top: 10px;
+  z-index: ${v.zIndex.pageHeader};
+
+  @media only screen and (max-width: ${v.responsive.smallBreakpoint}px) {
+    right: -20px;
+    left: 0;
+    top: 34px;
+  }
+
+  ${FilterIconHolder} {
+    margin-top: 7px !important;
+  }
+`
 
 @observer
 class CollectionFilter extends React.Component {

--- a/app/javascript/ui/filtering/FilterMenu.js
+++ b/app/javascript/ui/filtering/FilterMenu.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import FilterIcon from '~/ui/icons/FilterIcon'
 import PopoutMenu from '~/ui/global/PopoutMenu'
 
-const FilterIconHolder = styled.div`
+export const FilterIconHolder = styled.div`
   height: 40px;
   margin-right: 10px;
   ${props =>

--- a/app/javascript/ui/grid/CollectionGrid.js
+++ b/app/javascript/ui/grid/CollectionGrid.js
@@ -41,7 +41,7 @@ StyledGrid.displayName = 'StyledGrid'
 const SortContainer = styled.div`
   margin-bottom: 15px;
   margin-left: auto;
-  margin-right: 5px;
+  margin-right: 0;
   margin-top: -15px;
   text-align: right;
 `

--- a/app/javascript/ui/pages/CollectionPage.js
+++ b/app/javascript/ui/pages/CollectionPage.js
@@ -8,6 +8,9 @@ import { animateScroll as scroll } from 'react-scroll'
 import ClickWrapper from '~/ui/layout/ClickWrapper'
 import ChannelManager from '~/utils/ChannelManager'
 import CollectionGrid from '~/ui/grid/CollectionGrid'
+import CollectionFilter, {
+  SubmissionsFilterPositioner,
+} from '~/ui/filtering/CollectionFilter'
 import FoamcoreGrid from '~/ui/grid/FoamcoreGrid'
 import FloatingActionButton from '~/ui/global/FloatingActionButton'
 import Loader from '~/ui/layout/Loader'
@@ -413,8 +416,14 @@ class CollectionPage extends React.Component {
     }
 
     return (
-      <div>
+      <div style={{ position: 'relative' }}>
         {this.submissionsPageSeparator}
+        <SubmissionsFilterPositioner>
+          <CollectionFilter
+            collection={submissions_collection}
+            canEdit={collection.can_edit_content}
+          />
+        </SubmissionsFilterPositioner>
         <CollectionGrid
           {...gridSettings}
           loadCollectionCards={this.loadSubmissionsCollectionCards}


### PR DESCRIPTION
Not sure how it was removed.

I did find that it needed special styling for when the filter bar is
active. When in a submissions collection, it is always on the same
line with the sort menu, where in a normal collection, it moves from
above the bar to below it when the bar is active.

I also updated the mobile styles so it moves to the line below the
sort menu, as it's very difficult to find room for them both.