### PR TITLE
Update default collection cover color

### DIFF
--- a/__tests__/ui/global/charts/__snapshots__/ChartGroup.unit.test.js.snap
+++ b/__tests__/ui/global/charts/__snapshots__/ChartGroup.unit.test.js.snap
@@ -3888,7 +3888,7 @@ exports[`ChartGroup renders snapshot 1`] = `
       style={
         Object {
           "axis": Object {
-            "stroke": "#b6aaa6",
+            "stroke": "#c6c1bf",
             "strokeWidth": 30,
             "transform": "translateY(26px)",
           },

--- a/__tests__/ui/grid/__snapshots__/GridCard.unit.test.js.snap
+++ b/__tests__/ui/grid/__snapshots__/GridCard.unit.test.js.snap
@@ -17,7 +17,7 @@ exports[`GridCard when hoveringOver renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -7586,7 +7586,7 @@ exports[`GridCard when selected renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -15155,7 +15155,7 @@ exports[`GridCard with collection as editor renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -16571,7 +16571,7 @@ exports[`GridCard with collection as editor renders snapshot 1`] = `
   />
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder
@@ -23461,7 +23461,7 @@ exports[`GridCard with collection as viewer renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -24171,7 +24171,7 @@ exports[`GridCard with collection as viewer renders snapshot 1`] = `
   </StyledTopRightActions>
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder
@@ -31061,7 +31061,7 @@ exports[`GridCard with collection with SharedCollection card (menuDisabled = tru
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -38630,7 +38630,7 @@ exports[`GridCard with collection with SharedCollection renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -39340,7 +39340,7 @@ exports[`GridCard with collection with SharedCollection renders snapshot 1`] = `
   </StyledTopRightActions>
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder
@@ -46232,7 +46232,7 @@ exports[`GridCard with item as editor renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -46516,7 +46516,7 @@ exports[`GridCard with item as editor renders snapshot 1`] = `
   />
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder
@@ -47065,7 +47065,7 @@ exports[`GridCard with item as viewer renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -47209,7 +47209,7 @@ exports[`GridCard with item as viewer renders snapshot 1`] = `
   </StyledTopRightActions>
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder
@@ -47758,7 +47758,7 @@ exports[`GridCard with searchResult renders snapshot 1`] = `
   testCollectionCard={false}
 >
   <StyledTopRightActions
-    color="#b6aaa6"
+    color="#c6c1bf"
   >
     <TextActionMenu
       card={
@@ -49174,7 +49174,7 @@ exports[`GridCard with searchResult renders snapshot 1`] = `
   />
   <StyledTopRightActions
     className="show-on-hover"
-    color="#b6aaa6"
+    color="#c6c1bf"
     zoomLevel={1}
   >
     <CardActionHolder

--- a/app/javascript/utils/variables.js
+++ b/app/javascript/utils/variables.js
@@ -164,7 +164,7 @@ export default {
     commonLightest: '#f5f4f3',
     commonLight: '#f2f1ee',
     commonMediumTint: '#e3dedc',
-    commonMedium: '#b6aaa6',
+    commonMedium: '#c6c1bf',
     commonDark: '#a89f9b',
     commonDarkest: '#787878',
     primaryLightest: '#f0f4f6',


### PR DESCRIPTION
https://trello.com/c/Fc3jsRGR/2281-update-default-collection-cover-color

__Why:__
* Degloomify user experience

__What side effects does this change have?__
* Add new `collectionCover` color variable
* Change darkening collection cover overlay to only show conditionally

[old style image](https://www.dropbox.com/s/qg4nb9pqbxl68ld/Screenshot%202019-11-20%2016.10.22.png?dl=0)
[Updated style image](https://trello-attachments.s3.amazonaws.com/5a4ffcc478be1e8211a72d96/5dd49dcc4fad494c11de88c8/fade968941c5c385e20657e463b4c499/Screenshot_2019-11-20_16.01.04.png) 