### PR TITLE
Allow copy/paste for customizable question options

### DIFF
--- a/app/javascript/ui/test_collections/CustomizableQuestionChoice.js
+++ b/app/javascript/ui/test_collections/CustomizableQuestionChoice.js
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { Checkbox, Radio } from '~/ui/global/styled/forms'
 import { TextInput } from '~/ui/test_collections/shared'
 import TrashIcon from '~/ui/icons/TrashIcon'
+import v from '~/utils/variables'
 
 const ChoiceHolder = styled.div`
   background: ${props => props.theme.responseHolder};
@@ -23,6 +24,10 @@ const ChoiceHolder = styled.div`
 
     .TrashIcon {
       display: inline-block;
+      &:focus,
+      &:hover {
+        color: ${v.colors.commonDarkest};
+      }
     }
   }
 `
@@ -115,7 +120,6 @@ class CustomizableQuestionChoice extends React.Component {
             data-cy="CustomizableQuestionTextInput"
             disabled={!editing}
             inline="true"
-            className="test-designer-text-input"
           />
         </label>
         {editing && (

--- a/app/javascript/ui/test_collections/QuestionContentEditor.js
+++ b/app/javascript/ui/test_collections/QuestionContentEditor.js
@@ -94,8 +94,6 @@ class QuestionContentEditor extends React.Component {
           placeholder={placeholder}
           value={this.value}
           maxLength={maxLength}
-          // for ignoring global keypress
-          className="test-designer-text-input"
         />
         {optional && (
           <QuestionHelperWrapper

--- a/app/javascript/utils/captureGlobalKeypress.js
+++ b/app/javascript/utils/captureGlobalKeypress.js
@@ -40,6 +40,10 @@ export const handleMouseDownSelection = e => {
 const captureGlobalKeypress = e => {
   const { activeElement } = document
 
+  // none of the following card editing actions apply when you are editing a test
+  if (_.get(uiStore, 'viewingCollection.isTestCollection')) {
+    return false
+  }
   // allow normal keypress on input element, quill, and draftjs
   const shouldNormalKeyPressBeAllowed =
     activeElement.nodeName === 'INPUT' ||
@@ -48,7 +52,6 @@ const captureGlobalKeypress = e => {
       'public-DraftEditor-content',
       'edit-cover-title',
       'edit-cover-subtitle',
-      'test-designer-text-input',
     ]).length > 0
 
   if (shouldNormalKeyPressBeAllowed) return false


### PR DESCRIPTION
https://trello.com/c/kgUNOeSV/2283-05-cannot-copy-paste-into-the-single-multiple-choice-questions-in-feedback
__Why:__
* Allow users to copy and paste text when filling out single or multiple
choice question options

__This change addresses the need by:__
* Add allowed class to `CustomizableQuestionChoice`
* Exit `captureGlobalKeypress` early so user can paste text