### PR TITLE
Add cloned_from_id to Collection and Item serializers

### DIFF
--- a/app/serializers/serializable_collection.rb
+++ b/app/serializers/serializable_collection.rb
@@ -23,6 +23,7 @@ class SerializableCollection < BaseJsonSerializer
     :test_show_media,
     :idea_id,
     :search_term,
+    :cloned_from_id,
   )
 
   stringified_attributes(

--- a/app/serializers/serializable_item.rb
+++ b/app/serializers/serializable_item.rb
@@ -20,6 +20,7 @@ class SerializableItem < BaseJsonSerializer
     :archived,
     :unresolved_count,
     :last_unresolved_comment_id,
+    :cloned_from_id,
   )
 
   has_many :roles do

--- a/spec/support/api/schemas/collection.json
+++ b/spec/support/api/schemas/collection.json
@@ -54,7 +54,8 @@
     "cache_key": { "type": ["string"] },
     "test_show_media": { "type": ["boolean"] },
     "idea_id": { "type": ["string", "null"] },
-    "serializer": { "type": "string" }
+    "serializer": { "type": "string" },
+    "cloned_from_id": { "type": ["string", "null"] }
   },
   "required": ["name", "class_type", "created_at", "cover"]
 }

--- a/spec/support/api/schemas/item.json
+++ b/spec/support/api/schemas/item.json
@@ -36,7 +36,8 @@
     "is_restorable": { "type": ["boolean", "null"] },
     "default_group_id": { "type": ["string", "null"] },
     "unresolved_count": { "type": ["number"] },
-    "last_unresolved_comment_id": { "type": ["number", "null"] }
+    "last_unresolved_comment_id": { "type": ["number", "null"] },
+    "cloned_from_id": { "type": ["string", "null"] }
   },
   "required": ["class_type"]
 }


### PR DESCRIPTION
- So that we can use them on C∆ to compare and see if we've already cloned a collection/item before