### PR TITLE
Disable in app billing when adding C∆ org to Shape

### DIFF
--- a/app/services/organization_builder.rb
+++ b/app/services/organization_builder.rb
@@ -2,10 +2,10 @@ class OrganizationBuilder
   attr_reader :organization, :errors
 
   def initialize(params, user, full_setup: true)
-    @organization = Organization.new(name: params[:name])
-    @errors = @organization.errors
-    @user = user
     @params = params
+    @user = user
+    @organization = Organization.new(organization_params)
+    @errors = @organization.errors
     # mainly just in tests that we don't need this overhead
     @full_setup = full_setup
   end
@@ -83,5 +83,11 @@ class OrganizationBuilder
       organization: @organization,
       application: @user.application,
     )
+  end
+
+  def organization_params
+    return { name: @params[:name] } if @params[:in_app_billing].nil?
+
+    { name: @params[:name], in_app_billing: @params[:in_app_billing] }
   end
 end

--- a/spec/requests/api/v1/organizations_controller_spec.rb
+++ b/spec/requests/api/v1/organizations_controller_spec.rb
@@ -233,6 +233,21 @@ describe Api::V1::OrganizationsController, type: :request, json: true, auth: tru
       expect(json['data']['attributes']).to match_json_schema('organization')
     end
 
+    context 'setting in app billing' do
+      it 'does not accept the in_app_billing param if you are not super admin' do
+        post(path, params: json_api_params('organizations', name: 'IDEO U', in_app_billing: false))
+        # in_app_billing defaults to true (see app/models/organization.rb)
+        expect(json['data']['attributes']['in_app_billing']).to be(true)
+      end
+
+      it 'allows setting in_app_billing param if you are a super admin' do
+        user.add_role(Role::SUPER_ADMIN)
+        post(path, params: json_api_params('organizations', name: 'IDEO U', in_app_billing: false))
+
+        expect(json['data']['attributes']['in_app_billing']).to eql(false)
+      end
+    end
+
     context 'with invalid params' do
       let(:params) do
         json_api_params(


### PR DESCRIPTION
https://trello.com/c/BLGAAXxG/2424-shape-organization-created-from-c%E2%88%86-admin-did-not-have-in-app-billing-disabled
__Why:__
* Shape orgs created in C∆ admin should disable in app billing

__This change addresses the need by:__
* When building an organization, it will respect in_app_billing param