### PR TITLE
Fix bug with search collections preventing delete and move

### DIFF
--- a/app/javascript/ui/grid/ActionMenu.js
+++ b/app/javascript/ui/grid/ActionMenu.js
@@ -246,7 +246,8 @@ class ActionMenu extends React.Component {
       items = _.reject(items, { name: 'Replace' })
       if (
         record &&
-        (record.is_submission_box_template || record.isSearchCollection)
+        (record.is_submission_box_template ||
+          (record.parent && record.parent.isSearchCollection))
       ) {
         items = _.reject(items, { name: 'Delete' })
         items = _.reject(items, { name: 'Move' })


### PR DESCRIPTION
The logic had accidentally prevented search collections themselves from being deleted or moved, when instead we wanted to do that only if looking at a card within a search collection.