### PR TITLE
Fix position of avatar in pill

### DIFF
--- a/app/javascript/ui/global/Pill.js
+++ b/app/javascript/ui/global/Pill.js
@@ -52,8 +52,7 @@ const DeleteIconHolder = styled.span`
 const SymbolHolder = styled.span`
   width: ${props => props.symbolSize || 16}px;
   height: ${props => props.symbolSize || 16}px;
-  margin-right: ${props =>
-    !props.symbolSize || props.symbolSize === 16 ? 4 : 10}px;
+  margin-right: ${props => (props.selectable ? 6 : 12)}px;
 `
 
 const Pill = props => {
@@ -79,7 +78,7 @@ const Pill = props => {
     <PillWrapper {...wrapperProps}>
       {selectable && (
         <Checkbox
-          style={{ marginRight: '6px' }}
+          style={{ marginRight: '0px', marginLeft: '-4px' }}
           color="primary"
           checked={selected}
           onChange={ev => {
@@ -88,7 +87,11 @@ const Pill = props => {
           value="yes"
         />
       )}
-      {symbol && <SymbolHolder symbolSize={symbolSize}>{symbol}</SymbolHolder>}
+      {symbol && (
+        <SymbolHolder selectable={selectable} symbolSize={symbolSize}>
+          {symbol}
+        </SymbolHolder>
+      )}
       <DisplayText>{label}</DisplayText>
       {onDelete && (
         <DeleteIconHolder>

--- a/app/javascript/ui/global/PillList.js
+++ b/app/javascript/ui/global/PillList.js
@@ -38,7 +38,7 @@ class PillList extends React.Component {
       <ChipHolder>
         {itemList.map(item => {
           let avatar = null
-          let symbolSize = 16
+          const symbolSize = 16
           if (item.pic_url_square) {
             avatar = (
               <StyledAvatar
@@ -48,7 +48,6 @@ class PillList extends React.Component {
                 url={item.pic_url_square}
               />
             )
-            symbolSize = 26
           }
           if (item.icon) {
             avatar = <PillIconHolder>{item.icon}</PillIconHolder>


### PR DESCRIPTION
It was off because the styling for the add person to group pill and
the selectable collection filter pill were off. I added a new case
for positioning when it's a selecatable pill, and now the symbol
on the group pill is the correct, smaller size.