### PR TITLE
Fix tag typeahead

### DIFF
--- a/app/javascript/ui/filtering/FilterSearchModal.js
+++ b/app/javascript/ui/filtering/FilterSearchModal.js
@@ -24,8 +24,10 @@ class FilterSearchModal extends React.Component {
   }
 
   componentDidMount() {
-    runInAction(async () => {
-      this.tagNames = await this.getOrganizationTagList()
+    this.getOrganizationTagList().then(tags => {
+      runInAction(() => {
+        this.tagNames = tags
+      })
     })
   }
 


### PR DESCRIPTION
Tag typeahead was encountering an error:

```
Uncaught (in promise) Error: [mobx] Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: FilterSearchModal@5182.tagNames
```

I fixed it by having `runInaction()` directly wrap the setting of the observable, rather than wrap the returned promise from `async`.