### PR TITLE
handle virtual keyboard pushing activity box when placed activity box

### DIFF
--- a/app/javascript/ui/threads/CommentInput.js
+++ b/app/javascript/ui/threads/CommentInput.js
@@ -89,8 +89,8 @@ class CommentInput extends React.Component {
           // handle landscape and portrait differently
           const isPortrait = cols == 2
           const willBePushedByVirtualKeyboard = isPortrait
-            ? y > window.innerHeight / 2
-            : y > window.innerHeight / 2 - 200
+            ? decoratorRect.top > window.innerHeight / 2
+            : decoratorRect.top > window.innerHeight / 2 - 260
 
           // check if comment mentions are placed where virtual keyboard will be
           if (willBePushedByVirtualKeyboard) {


### PR DESCRIPTION
**Summary**
Comment mentions were being pushed by virtual keyboard on an iPad. This PR handles the issue by readjusting the position when an activity box is placed where the virtual keyboard will be.