### PR TITLE
Fix form button matching background and text color

### DIFF
--- a/app/javascript/ui/global/styled/buttons.js
+++ b/app/javascript/ui/global/styled/buttons.js
@@ -135,7 +135,7 @@ export const NamedActionButton = styled.button`
 NamedActionButton.defaultProps = {
   svgSize: { width: '30px', height: '30px' },
 }
-/* eslint-disable no-nested-ternary */
+
 /** @component */
 export const FormButton = styled.button`
   width: ${props => (props.width ? props.width : 183)}px;
@@ -223,9 +223,10 @@ const invertColor = color => {
     case v.colors.commonDark:
       return v.colors.commonLight
     case v.colors.white:
+      return v.colors.black
     case v.colors.commonMedium:
     case v.colors.black:
-      return v.colors.black
+      return v.colors.white
     default:
       return v.colors.white
   }


### PR DESCRIPTION
https://trello.com/c/MJVTQ0bL/2487-add-button-in-sharing-modal-text-is-black-once-adding-at-least-one-person-maybe-only-in-c%E2%88%86-collections

__Why:__
* Fix bug where text and button fill/background color were the same

__This change addresses the need by:__
* Provide inverted font colors to use with form buttons

[Production@12:12PM 2/6/20](https://www.dropbox.com/s/mu5sqnlj4ij291g/Screenshot%202020-02-06%2012.12.10.png?dl=0)

[Localhost example after changes](https://www.dropbox.com/s/b3cxx0vf32mgt0r/Screenshot%202020-02-06%2012.02.42.png?dl=0)