### PR TITLE
Fix sorting of method library filters

### DIFF
--- a/__tests__/ui/filtering/MethodLibraryFilterBar.unit.test.js
+++ b/__tests__/ui/filtering/MethodLibraryFilterBar.unit.test.js
@@ -1,3 +1,4 @@
+import { shuffle } from 'lodash'
 import MethodLibraryFilterBar from '~/ui/filtering/MethodLibraryFilterBar'
 import { fakeCollectionFilter } from '#/mocks/data'
 import {
@@ -37,22 +38,22 @@ describe('MethodLibraryFilterBar', () => {
         .find('.PopoutMenu-subqualities')
         .props()
         .menuItems.map(tag => tag.name)
-        .sort()
-    ).toEqual(allQualities.sort())
+    ).toEqual(allQualities) // Expected array order
 
     expect(
       wrapper
         .find('.PopoutMenu-categories')
         .props()
         .menuItems.map(tag => tag.name)
-    ).toEqual(methodLibraryTagsByType.categories)
+        .sort()
+    ).toEqual(methodLibraryTagsByType.categories.sort()) // Expected alphabetical order
 
     expect(
       wrapper
         .find('.PopoutMenu-types')
         .props()
         .menuItems.map(tag => tag.name)
-    ).toEqual(methodLibraryTagsByType.types)
+    ).toEqual(methodLibraryTagsByType.types.sort()) // Expected alphabetical order
   })
 
   it('renders creative qualities as pills', () => {
@@ -60,7 +61,29 @@ describe('MethodLibraryFilterBar', () => {
       wrapper
         .find('.creativeQualityTags')
         .props()
-        .itemList.map(tag => tag.name)
+        .itemList.map(tag => tag.name) // Expected array order
     ).toEqual([...creativeQualities.keys()])
+  })
+
+  describe('with collection filters in random order', () => {
+    beforeEach(() => {
+      props = {
+        filters: shuffle(methodLibraryTags).map(tag => ({
+          ...fakeCollectionFilter,
+          text: tag,
+        })),
+        onSelect: jest.fn(),
+      }
+      rerender()
+    })
+
+    it('renders creative qualities in correct order', () => {
+      expect(
+        wrapper
+          .find('.creativeQualityTags')
+          .props()
+          .itemList.map(tag => tag.name)
+      ).toEqual([...creativeQualities.keys()])
+    })
   })
 })

--- a/app/javascript/ui/filtering/MethodLibraryFilterBar.js
+++ b/app/javascript/ui/filtering/MethodLibraryFilterBar.js
@@ -1,4 +1,4 @@
-import { startCase, flatten } from 'lodash'
+import { startCase, flatten, sortBy } from 'lodash'
 import PropTypes from 'prop-types'
 import { Fragment } from 'react'
 import { observer, PropTypes as MobxPropTypes } from 'mobx-react'
@@ -84,19 +84,26 @@ class MethodLibraryFilterBar extends React.Component {
     const { filters } = this.props
     let tagNames
     if (type === 'creativeQualities') {
+      // Preserve original array order
       tagNames = [...creativeQualities.keys()]
     } else if (type === 'subqualities') {
+      // Preserve original array order
       tagNames = flatten(
         [...creativeQualities.values()].map(val => val.subqualities)
       )
     } else {
-      tagNames = methodLibraryTagsByType[type]
+      // These types should be in alphabetical order
+      tagNames = methodLibraryTagsByType[type].sort()
     }
     const matchingFilters = filters.filter(filter =>
       tagNames.includes(filter.text.toLowerCase())
     )
-    if (!onlySelected) return matchingFilters
-    return matchingFilters.filter(filter => filter.selected)
+    const sortedFilters = sortBy(matchingFilters, filter => {
+      // Sort by position in the array
+      return tagNames.indexOf(filter.text.toLowerCase())
+    })
+    if (!onlySelected) return sortedFilters
+    return sortedFilters.filter(filter => filter.selected)
   }
 
   selectFilter = filter => {


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Make sure C∆ fixed tag filters appear in the right order](https://trello.com/c/wqvEUq3f/2491-make-sure-c%E2%88%86-fixed-tag-filters-appear-in-the-right-order)