### PR TITLE
Let any user to add/remove legend item comparisons

### DIFF
--- a/__tests__/ui/grid/covers/LegendItemCover.unit.test.js
+++ b/__tests__/ui/grid/covers/LegendItemCover.unit.test.js
@@ -234,8 +234,8 @@ describe('LegendItemCover', () => {
       wrapper = shallow(<LegendItemCover.wrappedComponent {...props} />)
     })
 
-    it('should not show the comparison button', () => {
-      expect(wrapper.find('.test-add-comparison-button').exists()).toBe(false)
+    it('should show the comparison button', () => {
+      expect(wrapper.find('.test-add-comparison-button').exists()).toBe(true)
     })
   })
 })

--- a/app/javascript/ui/grid/covers/LegendItemCover.js
+++ b/app/javascript/ui/grid/covers/LegendItemCover.js
@@ -411,7 +411,7 @@ class LegendItemCover extends React.Component {
         <br />
         <StyledAddComparison>
           {comparisonMenuOpen && this.renderComparisonMenu}
-          {item.can_edit_content && !comparisonMenuOpen && (
+          {!comparisonMenuOpen && (
             <Heading3
               onClick={this.toggleComparisonSearch}
               role="button"


### PR DESCRIPTION
https://trello.com/c/ci0Y5ldE/2488-any-user-can-add-remove-comparisons-for-any-legend-item

__Why:__
* Allow any user to add or remove comparisons from any legend item.

__This change addresses the need by:__
* Remove requirement of `can_edit` from `LegendItemCover`