### PR TITLE
Fix 75th percentile comparison chart line

### DIFF
--- a/__tests__/ui/global/charts/ChartUtils.unit.test.js
+++ b/__tests__/ui/global/charts/ChartUtils.unit.test.js
@@ -53,7 +53,7 @@ describe('ChartUtils', () => {
   })
 
   describe('chartDomainForDatasetValues', () => {
-    it('returns max of values if no max specified', () => {
+    it('returns max of values if no max domain is specified', () => {
       const values = [{ value: 10 }, { value: 20 }]
       expect(chartDomainForDatasetValues({ values })).toEqual({
         x: [1, 2],
@@ -61,7 +61,15 @@ describe('ChartUtils', () => {
       })
     })
 
-    it('returns max given', () => {
+    it('returns max value if provided max is lower than highest value', () => {
+      const values = [{ value: 60 }, { value: 40 }]
+      expect(chartDomainForDatasetValues({ values, maxYDomain: 50 })).toEqual({
+        x: [1, 2],
+        y: [0, 60],
+      })
+    })
+
+    it('returns provided max domain if it is higher than highest value', () => {
       const values = [{ value: 10 }, { value: 20 }]
       expect(chartDomainForDatasetValues({ values, maxYDomain: 100 })).toEqual({
         x: [1, 2],

--- a/app/javascript/ui/global/charts/ChartUtils.js
+++ b/app/javascript/ui/global/charts/ChartUtils.js
@@ -71,7 +71,8 @@ export const chartDomainForDatasetValues = ({ values, maxYDomain }) => {
   let minXDomain
   let maxXDomain
   let calculatedMaxYDomain
-  if (maxYDomain) {
+
+  if (maxYDomain && maxYDomain > maxBy(values, 'value').value) {
     calculatedMaxYDomain = maxYDomain
   } else {
     calculatedMaxYDomain = maxBy(values, 'value').value


### PR DESCRIPTION
https://trello.com/c/eNzkOdLZ/2426-5-min-time-box-to-root-cause-then-then-prioritize-one-we-can-design-a-solution-usefulness-75th-percentile-score-not-showing-up-i

__Why:__
* Ensure that comparison datasets show up on charts, not "off the chart"

__This change addresses the need by:__
* Use the maximum value of a dataset instead of provided max Y domain if
the provided max Y domain is less than the max value in the dataset