### PR TITLE
Fix global search input unfocusing on new page

### DIFF
--- a/app/javascript/ui/layout/GlobalSearch.js
+++ b/app/javascript/ui/layout/GlobalSearch.js
@@ -65,8 +65,10 @@ class GlobalSearch extends React.Component {
 
   updateSearchText = text => {
     this.props.uiStore.update('searchText', text)
-    // perform a debounced search
-    this.search(this.searchText)
+    if (text.length > 3) {
+      // perform a debounced search
+      this.search(this.searchText)
+    }
   }
 
   onToggle = val => {

--- a/app/javascript/ui/pages/SearchPage.js
+++ b/app/javascript/ui/pages/SearchPage.js
@@ -26,7 +26,10 @@ class SearchPage extends React.Component {
     const { uiStore, location } = this.props
     const query = this.searchQuery(location)
     // initialize search bar to the queryString, e.g. when directly loading a search URL
-    uiStore.update('searchText', query)
+    uiStore.update('searchText', '')
+    setTimeout(() => {
+      uiStore.update('searchText', query)
+    }, 5)
 
     this.fetchData()
   }


### PR DESCRIPTION
For unknown reasons, the search input would unfocus when it gets to
the search page. The fix for this was a random timeout to update
the search text. Not totally sure what was wrong or why this worked.

Also, fixed so you have to type 4 letters to start a search.