### PR TITLE
Fix C∆ => Shape invite links so users can login

### DIFF
--- a/app/services/mailer_helper/application.rb
+++ b/app/services/mailer_helper/application.rb
@@ -26,7 +26,7 @@ module MailerHelper
     end
 
     def invite_url
-      "#{application.invite_url}?redirect=#{CGI.escape(shape_invite_url)}"
+      shape_invite_url
     end
 
     private

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -94,8 +94,8 @@ RSpec.describe InvitationMailer, type: :mailer do
           expect(mail.from).to eq(['help@ideocreativedifference.com'])
         end
 
-        it 'sets the invite url to creative difference' do
-          expect(mail.text_part.body).to match('https://creativedifference.ideo.com/shape')
+        it 'sets the invite url to Shape' do
+          expect(mail.text_part.body).to match("http://test.shape.com/invitations/#{user.invitation_token}")
         end
 
         it 'adds support message' do

--- a/spec/requests/api/v1/search_controller_spec.rb
+++ b/spec/requests/api/v1/search_controller_spec.rb
@@ -505,13 +505,13 @@ describe Api::V1::SearchController, type: :request, json: true, auth: true, sear
 
     it 'should find similar named users' do
       get(path, params: { query: @user.first_name })
-      expect(json['data'].select { |d| d['type'] == 'users' }.count).to be 2
+      expect(json['data'].select { |d| d['type'] == 'users' }.count).to eq 2
     end
 
     it 'should find org groups' do
       # the org is named "first_name last_name organization"
       get(path, params: { query: @user.first_name })
-      expect(json['data'].select { |d| d['type'] == 'groups' }.count).to be 3
+      expect(json['data'].select { |d| d['type'] == 'groups' }.count).to eq 3
     end
 
     context 'with application bot user' do

--- a/spec/services/mailer_helper/application_spec.rb
+++ b/spec/services/mailer_helper/application_spec.rb
@@ -64,9 +64,7 @@ RSpec.describe MailerHelper::Application, type: :service do
 
   describe '#invite_url' do
     it 'returns app invite_url' do
-      expect(subject.invite_url).to eq(
-        "https://creativedifference.ideo.com/shape?redirect=#{CGI.escape(url_helpers.root_url + 'company/')}",
-      )
+      expect(subject.invite_url).to eq(url_helpers.root_url.to_s + 'company/')
     end
 
     context 'with pending user' do
@@ -76,9 +74,7 @@ RSpec.describe MailerHelper::Application, type: :service do
         accept_invite_url = url_helpers.accept_invitation_url(
           token: user.invitation_token,
         )
-        expect(subject.invite_url).to eq(
-          "https://creativedifference.ideo.com/shape?redirect=#{CGI.escape(accept_invite_url)}",
-        )
+        expect(subject.invite_url).to eq(accept_invite_url)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/NMChLxmC/2510-fix-c%E2%88%86-shape-invites-so-that-you-can-login

__Why:__
* Allow users invited to Shape to login to Shape instead of being sent
to Creative Difference first before being returned with a redirect

__This change addresses the need by:__
* Change URL included in invitation email