### PR TITLE
Foamcore global zoom

### DIFF
--- a/__js_test_config/mocks/fakeUiStore.js
+++ b/__js_test_config/mocks/fakeUiStore.js
@@ -77,6 +77,7 @@ const fakeUiStore = {
   organizationMenuGroupId: null,
   organizationMenuOpen: false,
   expandedThreadKey: null,
+  zoomLevel: 1,
   expandThread: jest.fn(),
   openGroup: jest.fn(),
   openOptionalMenus: jest.fn(),
@@ -120,6 +121,9 @@ const fakeUiStore = {
   reselectCardIds: jest.fn(),
   setMovingCards: jest.fn(),
   drag: jest.fn(),
+  adjustZoomLevel: jest.fn(),
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
 }
 
 export default fakeUiStore

--- a/__tests__/stores/UiStore.unit.test.js
+++ b/__tests__/stores/UiStore.unit.test.js
@@ -111,4 +111,55 @@ describe('UiStore', () => {
       expect(uiStore.draggingFromMDL).toEqual(false)
     })
   })
+
+  describe('zoom functions', () => {
+    const collection = fakeCollection
+    beforeEach(() => {
+      collection.isBoard = true
+      collection.maxZoom = 3
+      uiStore.update('zoomLevel', 2)
+      // this is used by zoomIn/Out
+      uiStore.setViewingRecord(collection)
+    })
+
+    describe('#adjustZoomLevel', () => {
+      it('does not adjust unless collection is a board', () => {
+        uiStore.adjustZoomLevel({
+          collection: { ...collection, isBoard: false },
+        })
+        expect(uiStore.zoomLevel).toEqual(2)
+      })
+      it('should always revert to 1 if no showZoomControls is false', () => {
+        uiStore.adjustZoomLevel({
+          collection,
+          showZoomControls: false,
+        })
+        expect(uiStore.zoomLevel).toEqual(1)
+      })
+      it('when zoomed out, should adjust to collection.maxZoom', () => {
+        uiStore.adjustZoomLevel({ collection })
+        expect(uiStore.zoomLevel).toEqual(3)
+      })
+    })
+
+    describe('#zoomIn', () => {
+      it('reduces zoom number until it reaches 1', () => {
+        expect(uiStore.zoomLevel).toEqual(2)
+        uiStore.zoomIn()
+        expect(uiStore.zoomLevel).toEqual(1)
+        uiStore.zoomIn()
+        expect(uiStore.zoomLevel).toEqual(1)
+      })
+    })
+
+    describe('#zoomIn', () => {
+      it('increase zoom number until it reaches maxZoom', () => {
+        expect(uiStore.zoomLevel).toEqual(2)
+        uiStore.zoomOut()
+        expect(uiStore.zoomLevel).toEqual(3)
+        uiStore.zoomOut()
+        expect(uiStore.zoomLevel).toEqual(3)
+      })
+    })
+  })
 })

--- a/__tests__/ui/grid/FoamcoreGrid.unit.test.js
+++ b/__tests__/ui/grid/FoamcoreGrid.unit.test.js
@@ -432,10 +432,12 @@ describe('FoamcoreGrid', () => {
 
   describe('loadAfterScroll', () => {
     beforeEach(() => {
-      const { collection } = props
+      const { collection, uiStore } = props
       collection.loadedRows = 9
       collection.loadedCols = 9
       component.loadCards = jest.fn()
+      // zoomed out one level (this affects visibleRows)
+      uiStore.zoomLevel = 2
     })
 
     describe('scrolling in loaded bounds', () => {
@@ -537,12 +539,13 @@ describe('FoamcoreGrid', () => {
   describe('relativeZoomLevel', () => {
     beforeEach(() => {
       props.collection.num_columns = 16
+      props.collection.maxZoom = 3
+      props.uiStore.zoomLevel = 3
       rerender()
     })
     describe('when zoomed all the way out', () => {
       it('should return the ratio that shows the entire grid by default', () => {
         const maxGridWidth = 5472
-        expect(component.zoomLevel).toEqual(3)
         expect(component.maxGridWidth({ zoomLevel: 3 })).toEqual(maxGridWidth)
         expect(component.relativeZoomLevel).toEqual(
           maxGridWidth / jestInnerWidth
@@ -551,11 +554,19 @@ describe('FoamcoreGrid', () => {
     })
     describe('when zoomed in', () => {
       it('should return the zoomLevel', () => {
-        expect(component.zoomLevel).toEqual(3)
-        component.handleZoomIn()
-        expect(component.zoomLevel).toEqual(2)
+        props.uiStore.zoomLevel = 2
         expect(component.relativeZoomLevel).toEqual(2)
       })
+    })
+  })
+
+  describe('handleZoomIn/Out', () => {
+    it('should call the respective uiStore function', () => {
+      const { uiStore } = props
+      component.handleZoomIn()
+      expect(uiStore.zoomIn).toHaveBeenCalled()
+      component.handleZoomOut()
+      expect(uiStore.zoomOut).toHaveBeenCalled()
     })
   })
 
@@ -574,14 +585,17 @@ describe('FoamcoreGrid', () => {
     })
   })
 
-  describe('with a fourWide board', () => {
+  describe('with different board sizes', () => {
     beforeEach(() => {
       props.collection.num_columns = 4
       props.collection.isFourWideBoard = true
       rerender()
     })
-    it('should default to zoomLevel of 2', () => {
-      expect(component.zoomLevel).toEqual(2)
+    it('should call uiStore.adjustZoomLevel to ensure zoom is correct', () => {
+      expect(props.uiStore.adjustZoomLevel).toHaveBeenCalledWith({
+        collection: props.collection,
+        showZoomControls: true,
+      })
     })
   })
 })

--- a/app/javascript/stores/UiStore.js
+++ b/app/javascript/stores/UiStore.js
@@ -4,7 +4,11 @@ import { observable, action, runInAction, computed } from 'mobx'
 
 import routeToLogin from '~/utils/routeToLogin'
 import sleep from '~/utils/sleep'
-import v, { TOUCH_DEVICE_OS, EVENT_SOURCE_TYPES } from '~/utils/variables'
+import v, {
+  TOUCH_DEVICE_OS,
+  EVENT_SOURCE_TYPES,
+  FOAMCORE_MAX_ZOOM,
+} from '~/utils/variables'
 import { POPUP_ACTION_TYPES } from '~/enums/actionEnums'
 import { calculatePopoutMenuOffset } from '~/utils/clickUtils'
 import { getTouchDeviceOS } from '~/utils/detectOperatingSystem'
@@ -238,6 +242,8 @@ export default class UiStore {
   }
   @observable
   hoveringOverDataItem = false
+  @observable
+  zoomLevel = FOAMCORE_MAX_ZOOM
 
   @action
   setEditingCardCover(editingCardCoverId) {
@@ -1253,5 +1259,37 @@ export default class UiStore {
   @action
   updatePlaceholderPosition(position = {}) {
     _.assign(this.placeholderPosition, position)
+  }
+
+  // -----------------------
+  // Foamcore zoom functions
+  @action
+  adjustZoomLevel = ({ collection, showZoomControls = true } = {}) => {
+    if (!collection.isBoard) {
+      return
+    }
+    if (!showZoomControls) {
+      // when the full grid can fit in the window, zoom all the way in
+      this.zoomLevel = 1
+    } else if (this.zoomLevel > 1) {
+      // when switching collections readjust what "zoomed out" means
+      this.zoomLevel = collection.maxZoom
+    }
+  }
+
+  @action
+  zoomOut() {
+    const collection = this.viewingCollection
+    if (this.zoomLevel >= collection.maxZoom) {
+      this.zoomLevel = collection.maxZoom
+      return
+    }
+    this.zoomLevel = this.zoomLevel + 1
+  }
+
+  @action
+  zoomIn() {
+    if (this.zoomLevel === 1) return
+    this.zoomLevel = this.zoomLevel - 1
   }
 }

--- a/app/javascript/stores/jsonApi/Collection.js
+++ b/app/javascript/stores/jsonApi/Collection.js
@@ -19,6 +19,7 @@ import Item from './Item'
 import Role from './Role'
 import TestAudience from './TestAudience'
 import SharedRecordMixin from './SharedRecordMixin'
+import { FOAMCORE_MAX_ZOOM, FOUR_WIDE_MAX_ZOOM } from '~/utils/variables'
 import { POPUP_ACTION_TYPES } from '~/enums/actionEnums'
 import { methodLibraryTags } from '~/utils/creativeDifferenceVariables'
 
@@ -379,6 +380,10 @@ class Collection extends SharedRecordMixin(BaseRecord) {
 
   get isFourWideBoard() {
     return this.isBoard && this.num_columns === 4
+  }
+
+  get maxZoom() {
+    return this.isFourWideBoard ? FOUR_WIDE_MAX_ZOOM : FOAMCORE_MAX_ZOOM
   }
 
   get isPublicJoinable() {

--- a/app/javascript/utils/captureGlobalKeypress.js
+++ b/app/javascript/utils/captureGlobalKeypress.js
@@ -67,6 +67,7 @@ const captureGlobalKeypress = e => {
   let card
   const noCardsSelected =
     !viewingCollection || !ctrlKeypress || !selectedCardIds.length
+
   switch (code) {
     // CTRL+X: Move
     case 'KeyX':
@@ -119,7 +120,7 @@ const captureGlobalKeypress = e => {
       break
     // CTRL+A: Select All
     case 'KeyA':
-      if (ctrlKeypress && uiStore.viewingCollection) {
+      if (ctrlKeypress && viewingCollection) {
         e.preventDefault()
         uiStore.selectAll({ location: 'Global' })
       }
@@ -142,6 +143,19 @@ const captureGlobalKeypress = e => {
       const { editingCardCover } = uiStore
       if (editingCardCover) {
         uiStore.update('editingCardCover', null)
+      }
+      break
+    case 'Equal':
+    case 'Minus':
+      if (!ctrlKeypress || !viewingCollection || !viewingCollection.isBoard) {
+        return false
+      }
+      // prevent browser default zoom
+      e.preventDefault()
+      if (code === 'Equal') {
+        uiStore.zoomIn()
+      } else {
+        uiStore.zoomOut()
       }
       break
     default:

--- a/app/javascript/utils/variables.js
+++ b/app/javascript/utils/variables.js
@@ -15,6 +15,9 @@ export const AUDIENCE_PRICES = {
     4.0,
 }
 
+export const FOAMCORE_MAX_ZOOM = 3
+export const FOUR_WIDE_MAX_ZOOM = 2
+
 export const ITEM_TYPES = {
   TEXT: 'Item::TextItem',
   FILE: 'Item::FileItem',


### PR DESCRIPTION
- Refactor Foamcore zoomLevel to be globally tracked in uiStore
- allows global keypress of "CMD +/-" to trigger Foamcore zooming 
(overriding default browser zoom)