### PR TITLE
Add test for multiple search filters

### DIFF
--- a/app/services/search.rb
+++ b/app/services/search.rb
@@ -1,22 +1,24 @@
 class Search
   attr_reader :options
 
-  DEFAULT_OPTIONS = {
-    fields: [
-      'name^50',
-      'handle^50',
-      'tags^20',
-      'content',
-    ],
-    # `missing` just means this field is allowed to be missing
-    boost_by: { activity_count: { factor: 0.2, missing: 0 } },
-    per_page: 10,
-    page: 1,
-    where: {},
-  }.freeze
+  def self.default_options
+    {
+      fields: [
+        'name^50',
+        'handle^50',
+        'tags^20',
+        'content',
+      ],
+      # `missing` just means this field is allowed to be missing
+      boost_by: { activity_count: { factor: 0.2, missing: 0 } },
+      per_page: 10,
+      page: 1,
+      where: {},
+    }
+  end
 
   def initialize(options = {})
-    @options = DEFAULT_OPTIONS.merge(options)
+    @options = self.class.default_options.merge(options)
   end
 
   def search(query)

--- a/spec/services/search_spec.rb
+++ b/spec/services/search_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Search do
       expect(
         search.options[:where],
       ).to eq(
-        parent_ids: { all: [123456] },
+        parent_ids: { all: [123_456] },
         tags: { all: ['case study'] },
       )
     end


### PR DESCRIPTION
And fix tests so that the `filters` method isn't stubbed out for all tests.