### PR TITLE
Include linked parent collections in search data

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -270,12 +270,6 @@ class Collection < ApplicationRecord
       ]
   end
 
-  def parent_ids
-    (
-      Array.wrap(breadcrumb) + cards_linked_to_this_collection.collection.pluck(:parent_id)
-    ).uniq
-  end
-
   # By default all string fields are searchable
   def search_data
     updated_date = Arel.sql('DATE(updated_at)')

--- a/app/models/concerns/breadcrumbable.rb
+++ b/app/models/concerns/breadcrumbable.rb
@@ -44,6 +44,19 @@ module Breadcrumbable
     Item.in_collection(self, order: nil)
   end
 
+  # used for indexing search_data e.g. to surface linked items/collections
+  def parent_ids
+    cards_linked = []
+    if is_a?(Item)
+      cards_linked = cards_linked_to_this_item
+    elsif is_a?(Collection)
+      cards_linked = cards_linked_to_this_collection
+    end
+    (
+      Array.wrap(breadcrumb) + cards_linked.pluck(:parent_id)
+    ).uniq
+  end
+
   def parents
     Collection.where(id: breadcrumb)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -227,6 +227,7 @@ class Item < ApplicationRecord
       content: search_content,
       user_ids: search_user_ids,
       parent_id: parent&.id,
+      parent_ids: parent_ids,
       group_ids: search_group_ids,
       organization_id: organization_id,
       archived: archived,

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -772,27 +772,6 @@ describe Collection, type: :model do
     end
   end
 
-  describe '#parent_ids' do
-    let(:parent) { create(:collection) }
-    let(:collection) { create(:collection, parent_collection: parent)}
-
-    it 'includes parent collection ids' do
-      expect(collection.search_data[:parent_ids]).to eq([parent.id])
-    end
-
-    context 'if linked' do
-      let(:linked_collection) { create(:collection) }
-      let!(:link_card) { create(:collection_card_link, parent: linked_collection, collection: collection) }
-      before { collection.reload } # refresh relationships
-
-      it 'includes parents where it was linked' do
-        expect(collection.parent_ids).to match_array(
-          [parent.id, linked_collection.id],
-        )
-      end
-    end
-  end
-
   describe '#unarchive_cards!' do
     let(:collection) { create(:collection, num_cards: 3) }
     let(:cards) { collection.all_collection_cards }

--- a/spec/models/concerns/breadcrumbable_spec.rb
+++ b/spec/models/concerns/breadcrumbable_spec.rb
@@ -109,6 +109,37 @@ describe Breadcrumbable, type: :concern do
     end
   end
 
+  describe '#parent_ids' do
+    let(:parent) { create(:collection) }
+    let(:collection) { create(:collection, parent_collection: parent) }
+    let(:item) { create(:text_item, parent_collection: parent) }
+
+    it 'includes parent collection ids' do
+      expect(collection.search_data[:parent_ids]).to eq([parent.id])
+      expect(item.search_data[:parent_ids]).to eq([parent.id])
+    end
+
+    context 'if linked' do
+      let(:linked_collection) { create(:collection) }
+      let!(:link_card) { create(:collection_card_link, parent: linked_collection, collection: collection) }
+      let!(:link_item_card) { create(:collection_card_link, parent: linked_collection, item: item) }
+      before do
+        # refresh relationships
+        collection.reload
+        item.reload
+      end
+
+      it 'includes parents where it was linked' do
+        expect(collection.parent_ids).to match_array(
+          [parent.id, linked_collection.id],
+        )
+        expect(item.parent_ids).to match_array(
+          [parent.id, linked_collection.id],
+        )
+      end
+    end
+  end
+
   describe '#detect_infinite_loop' do
     let(:collection) { create(:collection) }
     context 'with long breadcrumb' do


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [When search collections are searching a collection, they should surface links in addition to other content](https://trello.com/c/lUux2fbX/2583-when-search-collections-are-searching-a-collection-they-should-surface-links-in-addition-to-other-content)