### PR TITLE
Fix the first user collection having content loading

### DIFF
--- a/app/services/organization_assigner.rb
+++ b/app/services/organization_assigner.rb
@@ -24,11 +24,10 @@ class OrganizationAssigner < SimpleService
 
         create_network_organization
         create_network_subscription
-      else
-        @user.current_user_collection(@organization.id).update(
-          loading_content: false,
-        )
       end
+      @user.current_user_collection(@organization.id).update(
+        loading_content: false,
+      )
       OrganizationShellWorker.perform_async
     end
     !result.nil?

--- a/spec/services/organization_assigner_spec.rb
+++ b/spec/services/organization_assigner_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe OrganizationAssigner, type: :service do
     end
 
     context 'with a shell organization' do
+      let(:user_collection) do
+        Collection::UserCollection.find_by(organization: builder.organization)
+      end
+
       before do
         allow(OrganizationShellWorker).to receive(:perform_async)
         builder.call
@@ -43,13 +47,15 @@ RSpec.describe OrganizationAssigner, type: :service do
       end
 
       it 'should assign the user collection to the user' do
-        user_collection = Collection::UserCollection.find_by(organization:
-                                                             builder.organization)
         expect(user.has_role?(Role::EDITOR, user_collection)).to be true
       end
 
       it 'should call OrganizationShellWorker to set up the next shell org' do
         expect(OrganizationShellWorker).to have_received(:perform_async)
+      end
+
+      it 'should set loading_content to false' do
+        expect(user_collection.loading_content).to be false
       end
     end
 


### PR DESCRIPTION
The org assigner should always unset the content loading attribute
so the first user can see their getting started collection.