### PR TITLE
Fixes text losing formatting after highlight

### DIFF
--- a/app/javascript/stores/UiStore.js
+++ b/app/javascript/stores/UiStore.js
@@ -1104,6 +1104,10 @@ export default class UiStore {
     const { range } = selectedTextRangeForCard
     if (!currentQuillEditor || !range || !range.length) return
 
+    const currentFormat = currentQuillEditor.getFormat(
+      range.index,
+      range.length
+    )
     // if no record then un-highlight
     const val = record ? 'new' : false
     currentQuillEditor.formatText(
@@ -1112,6 +1116,7 @@ export default class UiStore {
       {
         commentHighlight: val,
         commentHighlightResolved: false,
+        ...currentFormat,
       },
       'api'
     )

--- a/app/javascript/stores/jsonApi/Item.js
+++ b/app/javascript/stores/jsonApi/Item.js
@@ -325,10 +325,8 @@ class Item extends SharedRecordMixin(BaseRecord) {
     // pick up "new" highlights that are currently in our quillEditor
     _.each(delta.ops, op => {
       if (op.attributes && op.attributes.commentHighlight === 'new') {
-        op.attributes = {
-          // replace them with persisted comment id
-          commentHighlight: commentId,
-        }
+        op.attributes = op.attributes || {}
+        op.attributes.commentHighlight = commentId
       }
     })
     // now set this local quill_data to have the new highlight + commentId


### PR DESCRIPTION
This fixes it by perserving the formatting dating both when the
highlight is happening and when you save the highlight to the
backend data.