### PR TITLE
fix closing action menu on GridCard mouseleave

### DIFF
--- a/app/javascript/ui/grid/GridCard.js
+++ b/app/javascript/ui/grid/GridCard.js
@@ -282,11 +282,6 @@ class GridCard extends React.Component {
     }
   }
 
-  closeContextMenu = () => {
-    // this happens any time you mouse off the whole card
-    uiStore.closeCardMenu()
-  }
-
   linkOffsite = url => {
     const { record } = this.props
     Activity.trackActivity('viewed', record)
@@ -525,7 +520,6 @@ class GridCard extends React.Component {
         data-cy="GridCard"
         onContextMenu={this.openContextMenu}
         ref={c => (this.gridCardRef = c)}
-        onMouseLeave={this.closeContextMenu}
         selected={this.isSelected || this.props.hoveringOver}
         inSearchPage={searchResult}
       >


### PR DESCRIPTION
It looks like `ActionMenu::handleMouseLeave` already has a method which closes the action menu, and `GridCard::closeContextMenu` was duplicated logic which caused the bug.