### PR TITLE
Disappearing card fix (on multiple orgs)

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -225,4 +225,10 @@ class Api::V1::BaseController < ApplicationController
   def collection_broadcaster(collection = @collection)
     CollectionUpdateBroadcaster.new(collection, current_user)
   end
+
+  def switch_to_organization
+    return if @collection.common_viewable?
+
+    current_user.switch_to_organization(@collection.organization)
+  end
 end

--- a/app/controllers/api/v1/collection_cards_controller.rb
+++ b/app/controllers/api/v1/collection_cards_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
   before_action :load_and_authorize_collection_card_update, only: %i[update_card_filter]
   before_action :check_cache, only: %i[index ids breadcrumb_records]
   before_action :load_collection_cards, only: %i[index ids breadcrumb_records]
+
   def index
     render_collection_cards
   end
@@ -310,6 +311,8 @@ class Api::V1::CollectionCardsController < Api::V1::BaseController
   end
 
   def load_collection_cards
+    # always ensure we're on @collection.organization first
+    switch_to_organization
     ids_only = params[:action] == 'ids'
     filter_params = params[:filter].present? ? params[:filter] : params
     filter_params.merge(q: params[:q]) if params[:q].present?

--- a/app/controllers/api/v1/collections_controller.rb
+++ b/app/controllers/api/v1/collections_controller.rb
@@ -427,10 +427,4 @@ class Api::V1::CollectionsController < Api::V1::BaseController
     # only add_role if it's not the guest group
     current_user.add_role(Role::MEMBER, group) unless group.guest?
   end
-
-  def switch_to_organization
-    return if @collection.common_viewable?
-
-    current_user.switch_to_organization(@collection.organization)
-  end
 end

--- a/spec/requests/api/v1/collection_cards_controller_spec.rb
+++ b/spec/requests/api/v1/collection_cards_controller_spec.rb
@@ -49,6 +49,25 @@ describe Api::V1::CollectionCardsController, type: :request, json: true, auth: t
       expect(json['data'].map { |cc| cc['id'].to_i }).to match_array(collection.collection_card_ids)
     end
 
+    context 'on different org' do
+      let(:first_org) { create(:organization, member: user) }
+      let!(:other_org) { create(:organization, member: user) }
+      let!(:collection) do
+        create(:collection, organization: other_org, add_viewers: [user])
+      end
+
+      before do
+        user.switch_to_organization(first_org)
+      end
+
+      it 'should switch the user to the org' do
+        expect(user.current_organization).to eq first_org
+        get(path)
+        expect(response.status).to eq(200)
+        expect(user.reload.current_organization).to eq other_org
+      end
+    end
+
     describe 'included' do
       let(:items_json) { json_included_objects_of_type('items') }
 

--- a/spec/requests/api/v1/collections_controller_spec.rb
+++ b/spec/requests/api/v1/collections_controller_spec.rb
@@ -258,15 +258,21 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
     end
 
     context 'on different org' do
+      let!(:first_org) { create(:organization, member: user) }
       let!(:other_org) { create(:organization, member: user) }
       let!(:collection) do
         create(:collection, organization: other_org, add_viewers: [user])
       end
 
+      before do
+        user.switch_to_organization(first_org)
+      end
+
       it 'should switch the user to the org' do
+        expect(user.current_organization).to eq first_org
         get(path)
         expect(response.status).to eq(200)
-        expect(user.current_organization).to eq other_org
+        expect(user.reload.current_organization).to eq other_org
       end
 
       context 'with a common_viewable resource' do
@@ -277,7 +283,7 @@ describe Api::V1::CollectionsController, type: :request, json: true, auth: true 
         it 'should not switch the user to the org' do
           get(path)
           expect(response.status).to eq(200)
-          expect(user.current_organization).not_to eq other_org
+          expect(user.reload.current_organization).not_to eq other_org
         end
       end
     end


### PR DESCRIPTION
the fix:
- collection_cards_controller#index also switches the user to the correct org

- was probably an issue with multiple threads/dynos where you would hit 
the collection, switching you to the org, but the cards endpoint was 
still seemingly not switched so its usage of `user.current_organization` 
was incorrect