### PR TITLE
fix org settings tag editor

### DIFF
--- a/app/javascript/ui/organizations/OrganizationSettings.js
+++ b/app/javascript/ui/organizations/OrganizationSettings.js
@@ -140,8 +140,30 @@ class OrganizationSettings extends React.Component {
     }
   }
 
-  afterAddRemoveDomainTag = () => {
+  @action
+  addTag = ({ label }) => {
+    const { domain_whitelist } = this.organization
+    if (_.indexOf(domain_whitelist, label) < 0) {
+      domain_whitelist.push(label)
+      this.organization.patch()
+    }
+  }
+
+  @action
+  removeTag = ({ label }) => {
+    _.pull(this.organization.domain_whitelist, label)
     this.organization.patch()
+  }
+
+  get domainWhiteListFormattedTags() {
+    const { organization } = this
+    const { domain_whitelist } = organization
+
+    return _.map(domain_whitelist, label => {
+      return {
+        label,
+      }
+    })
   }
 
   render() {
@@ -152,15 +174,13 @@ class OrganizationSettings extends React.Component {
           Any new people added to {this.organization.name} without these email
           domains will be considered guests.
         </p>
-        // FIXME: will break when tags are used with organization domains...
         <TagEditor
+          recordTags={this.domainWhiteListFormattedTags}
+          afterAddTag={this.addTag}
+          afterRemoveTag={this.removeTag}
           canEdit
-          validateTag={this.validateDomainTag}
           placeholder="Please enter domains with the following format: domain.com"
-          records={[this.organization]}
           tagColor="white"
-          afterAddTag={this.afterAddRemoveDomainTag}
-          afterRemoveTag={this.afterAddRemoveDomainTag}
         />
         <br />
         <Heading2>Terms of Use</Heading2>

--- a/app/javascript/ui/pages/shared/TagEditor.js
+++ b/app/javascript/ui/pages/shared/TagEditor.js
@@ -154,7 +154,7 @@ TagEditor.propTypes = {
   tagColor: PropTypes.string,
   placeholder: PropTypes.string,
   validateTag: PropTypes.func,
-  suggestions: PropTypes.array.isRequired,
+  suggestions: PropTypes.array,
   handleInputChange: PropTypes.func,
 }
 
@@ -163,6 +163,7 @@ TagEditor.defaultProps = {
   tagColor: 'gray',
   placeholder: 'Add new tags, separated by comma or pressing enter.',
   validateTag: null,
+  suggestions: [],
   handleInputChange: undefined,
 }
 


### PR DESCRIPTION
Org settings was using `TagEditor` which had regressions after adding new logic to handle people tags