### PR TITLE
Don't show challenge settings button to non-editors

### DIFF
--- a/__tests__/ui/challenges/ChallengeHeaderButton.unit.test.js
+++ b/__tests__/ui/challenges/ChallengeHeaderButton.unit.test.js
@@ -8,13 +8,17 @@ describe('ChallengeHeaderButton', () => {
     props = {
       record: {
         ...fakeCollection,
-        collection_type: 'challenge',
         isChallengeOrInsideChallenge: true,
         API_fetchAllReviewableSubmissions: jest
           .fn()
           .mockReturnValue(Promise.resolve([])),
         fetchChallengeReviewersGroup: jest.fn(),
         canEdit: false,
+        challenge: {
+          ...fakeCollection,
+          canEdit: false,
+          collection_type: 'challenge',
+        },
       },
       apiStore: fakeApiStore(),
     }
@@ -34,7 +38,7 @@ describe('ChallengeHeaderButton', () => {
 
   describe('if user can edit collection', () => {
     beforeEach(() => {
-      props.record.canEdit = true
+      props.record.challenge.canEdit = true
       rerender()
     })
 
@@ -48,7 +52,7 @@ describe('ChallengeHeaderButton', () => {
     beforeEach(() => {
       props.record.isSubmissionBox = true
       props.record.isChallengeOrInsideChallenge = true
-      props.record.canEdit = true
+      props.record.challenge.canEdit = true
       rerender()
     })
 

--- a/app/javascript/ui/challenges/ChallengeHeaderButton.js
+++ b/app/javascript/ui/challenges/ChallengeHeaderButton.js
@@ -18,7 +18,11 @@ class ChallengeHeaderButton extends React.Component {
 
     if (!record.isChallengeOrInsideChallenge) return null
 
-    if (!record.isSubmissionBox && record.canEdit) {
+    if (
+      !record.isSubmissionBox &&
+      record.challenge &&
+      record.challenge.canEdit
+    ) {
       return (
         <Button
           {...buttonStyleProps}


### PR DESCRIPTION
Fix so it checks the challenge record, not the given record for the page.