### PR TITLE
Collection covers overlapping

### DIFF
--- a/app/javascript/ui/grid/shared.js
+++ b/app/javascript/ui/grid/shared.js
@@ -221,7 +221,7 @@ export const StyledGridCardInner = styled.div`
   ${props =>
     !props.hasOverflow &&
     `
-  overflow: ${props => (props.visibleOverflow ? 'visible' : 'hidden')};
+  overflow: ${props.visibleOverflow ? 'visible' : 'hidden'};
   `} z-index: 1;
   ${props =>
     !props.isText &&


### PR DESCRIPTION
It was broken because props was already defined but this defnined
another method to pull out the props would rendered as invalid CSS
so the overflow property wasn't being set at all.