### PR TITLE
Fixes for dynamic vertical scrolling

### DIFF
--- a/app/javascript/ui/Routes.js
+++ b/app/javascript/ui/Routes.js
@@ -144,6 +144,12 @@ class Routes extends React.Component {
     // Return if mouse is only scrolling, not click-dragging
     if (!this.mouseDownAt.x) return
 
+    // End selection if the mouse button isn't down. for when you drag
+    // out of browser screen.
+    if (e.buttons === 0) {
+      this.handleMouseUpSelection(e)
+    }
+
     // Stop propagation if dragging so it doesn't trigger other events
     e.stopPropagation()
     e.preventDefault()

--- a/app/javascript/utils/ScrollNearPageBoundsService.js
+++ b/app/javascript/utils/ScrollNearPageBoundsService.js
@@ -17,6 +17,11 @@ export default class ScrollNearPageBoundsService {
     this.speed = speed
     this.setScrolling(false)
 
+    let topScrollTriggerDyn = v.topScrollTrigger
+    if (window.innerHeight < 800) {
+      topScrollTriggerDyn = window.innerHeight / 8
+    }
+
     // NOTE: these hide so that we can fully control the page scroll
     // otherwise the browser will *also* try to scroll when you hit the edges;
     // however, there is some UI helpfulness lost if you can't see the scrollbars :(
@@ -28,16 +33,16 @@ export default class ScrollNearPageBoundsService {
     const changedTouch = e.changedTouches ? e.changedTouches[0] : {}
     // Vertical Scroll
     if (
-      e.clientY < v.topScrollTrigger ||
-      (uiStore.isTouchDevice && changedTouch.clientY < v.topScrollTrigger)
+      e.clientY < topScrollTriggerDyn ||
+      (uiStore.isTouchDevice && changedTouch.clientY < topScrollTriggerDyn)
     ) {
       // At top of viewport
       this.scrolling = true
       this.scrollUp(null, e.clientY)
     } else if (
-      e.clientY > window.innerHeight - v.topScrollTrigger ||
+      e.clientY > window.innerHeight - topScrollTriggerDyn ||
       (uiStore.isTouchDevice &&
-        changedTouch.clientY > window.innerHeight - v.topScrollTrigger)
+        changedTouch.clientY > window.innerHeight - v.topScrollTriggerDyn)
     ) {
       // At bottom of viewport
       this.scrolling = true


### PR DESCRIPTION
The fix was to dynamically set the vertical bounds when on mobile so it's a percentage of the total height. On screens above 800px in height, it defaults the 200 as before. This seemed to work better in my own testing, as I wasn't getting stuck in a scroll.

My fix for the selection area was to use a `buttons` attribute on the event which should mean a button is being pressed down. I'm not sure how this works on actual mobile, so would have to test.